### PR TITLE
Add comment feature with likes

### DIFF
--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -27,6 +27,7 @@ model User {
   comments        Comment[]         @relation("UserComments")
   posts           Post[]            @relation("UserPosts")
   interactions    PostInteraction[]
+  commentLikes    CommentLike[]
 
   @@unique([provider, providerId], name: "provider_providerId")
 }
@@ -51,9 +52,22 @@ model Comment {
   postId    String
   authorId  String
   text      String
+  likes     Int      @default(0)
   createdAt DateTime @default(now())
   author    User     @relation("UserComments", fields: [authorId], references: [id])
   post      Post     @relation("PostComments", fields: [postId], references: [id])
+  likedBy   CommentLike[]
+}
+
+model CommentLike {
+  id        String   @id @default(uuid())
+  comment   Comment  @relation(fields: [commentId], references: [id])
+  commentId String
+  user      User     @relation(fields: [userId], references: [id])
+  userId    String
+  createdAt DateTime @default(now())
+
+  @@unique([commentId, userId], name: "one_like_per_user_per_comment")
 }
 
 model PostInteraction {

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -9,6 +9,7 @@ import { PrismaModule }   from './prisma/prisma.module';
 import { AuthModule }    from './auth/auth.module';
 import { RequestLoggingMiddleware }  from './middleware/logging.middleware';
 import { PostsModule } from './posts/post.module';
+import { CommentsModule } from './comments/comments.module';
 
 
 
@@ -21,8 +22,9 @@ import { PostsModule } from './posts/post.module';
     SupabaseModule.forRoot(),
     PrismaModule,
     AuthModule,
-    PostsModule
-    
+    PostsModule,
+    CommentsModule
+
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/backend/src/comments/comments.controller.ts
+++ b/backend/src/comments/comments.controller.ts
@@ -1,0 +1,30 @@
+import { Controller, Get, Post, Body, Param, Req, UseGuards } from '@nestjs/common';
+import { JwtAuthGuard } from '../auth/jwt-auth.guard';
+import { OptionalAuthGuard } from '../auth/jwt-optional.guard';
+import { CommentsService } from './comments.service';
+import { CreateCommentDto } from './dto/create-comment.dto';
+
+@Controller('api')
+export class CommentsController {
+  constructor(private readonly comments: CommentsService) {}
+
+  @UseGuards(OptionalAuthGuard)
+  @Get('posts/:postId/comments')
+  getComments(@Param('postId') postId: string) {
+    return this.comments.getCommentsForPost(postId);
+  }
+
+  @UseGuards(JwtAuthGuard)
+  @Post('posts/:postId/comments')
+  create(@Req() req: any, @Param('postId') postId: string, @Body() dto: CreateCommentDto) {
+    const userId = req.user.sub as string;
+    return this.comments.createComment(userId, postId, dto);
+  }
+
+  @UseGuards(JwtAuthGuard)
+  @Post('comments/:id/like')
+  toggleLike(@Req() req: any, @Param('id') id: string) {
+    const userId = req.user.sub as string;
+    return this.comments.toggleLike(userId, id);
+  }
+}

--- a/backend/src/comments/comments.module.ts
+++ b/backend/src/comments/comments.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+import { PrismaModule } from '../prisma/prisma.module';
+import { CommentsService } from './comments.service';
+import { CommentsController } from './comments.controller';
+
+@Module({
+  imports: [PrismaModule],
+  providers: [CommentsService],
+  controllers: [CommentsController],
+})
+export class CommentsModule {}

--- a/backend/src/comments/comments.service.ts
+++ b/backend/src/comments/comments.service.ts
@@ -1,0 +1,60 @@
+import { Injectable } from '@nestjs/common';
+import { PrismaService } from '../prisma/prisma.service';
+import { CreateCommentDto } from './dto/create-comment.dto';
+
+@Injectable()
+export class CommentsService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async createComment(userId: string, postId: string, dto: CreateCommentDto) {
+    return this.prisma.comment.create({
+      data: { text: dto.text, authorId: userId, postId },
+    });
+  }
+
+  async getCommentsForPost(postId: string) {
+    const list = await this.prisma.comment.findMany({
+      where: { postId },
+      orderBy: { createdAt: 'asc' },
+      include: {
+        author: { select: { username: true, avatarUrl: true } },
+      },
+    });
+    return list.map(c => ({
+      id: c.id,
+      text: c.text,
+      authorId: c.authorId,
+      username: c.author.username!,
+      avatarUrl: c.author.avatarUrl ?? '',
+      timestamp: c.createdAt.toISOString(),
+      likes: c.likes,
+    }));
+  }
+
+  async toggleLike(userId: string, commentId: string) {
+    try {
+      await this.prisma.commentLike.create({ data: { userId, commentId } });
+      const updated = await this.prisma.comment.update({
+        where: { id: commentId },
+        data: { likes: { increment: 1 } },
+        select: { likes: true },
+      });
+      return { liked: true, count: updated.likes };
+    } catch (e: any) {
+      if (e.code === 'P2002') {
+        await this.prisma.commentLike.delete({
+          where: {
+            one_like_per_user_per_comment: { commentId, userId },
+          },
+        });
+        const updated = await this.prisma.comment.update({
+          where: { id: commentId },
+          data: { likes: { decrement: 1 } },
+          select: { likes: true },
+        });
+        return { liked: false, count: updated.likes };
+      }
+      throw e;
+    }
+  }
+}

--- a/backend/src/comments/dto/create-comment.dto.ts
+++ b/backend/src/comments/dto/create-comment.dto.ts
@@ -1,0 +1,3 @@
+export class CreateCommentDto {
+  text: string;
+}


### PR DESCRIPTION
## Summary
- support comments on posts
- allow liking comments
- expose comment API routes
- update Prisma schema for comment likes

## Testing
- `npm test` *(fails: should return "Hello World!", received "Hello there")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68893d3a03388327818d450ea25e91af