### PR TITLE
Add comment deletion and layout tweaks

### DIFF
--- a/astrogram/src/components/Comments/Comments.tsx
+++ b/astrogram/src/components/Comments/Comments.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState, FormEvent } from 'react';
 import { useAuth } from '../../contexts/AuthContext';
-import { fetchComments, createComment } from '../../lib/api';
+import { fetchComments, createComment, deleteComment } from '../../lib/api';
 
 export interface CommentItem {
   id: string;
@@ -38,28 +38,19 @@ const Comments: React.FC<{ postId: string }> = ({ postId }) => {
     }
   };
 
+  const handleDelete = async (id: string) => {
+    try {
+      await deleteComment(id);
+      setComments((c) => c.filter((cm) => cm.id !== id));
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
   return (
     <div className="mt-4 space-y-4">
-      {loading ? (
-        <div>Loading comments…</div>
-      ) : (
-        comments.map((c) => (
-          <div key={c.id} className="flex gap-2">
-            <img
-              src={c.avatarUrl}
-              alt="avatar"
-              className="w-8 h-8 rounded-full object-cover"
-            />
-            <div>
-              <div className="text-sm text-teal-400">@{c.username}</div>
-              <div className="text-sm text-gray-200">{c.text}</div>
-            </div>
-          </div>
-        ))
-      )}
-
       {user && (
-        <form onSubmit={handleSubmit} className="flex gap-2 items-start mt-4">
+        <form onSubmit={handleSubmit} className="flex gap-2 items-start">
           <textarea
             value={text}
             onChange={(e) => setText(e.target.value)}
@@ -74,6 +65,32 @@ const Comments: React.FC<{ postId: string }> = ({ postId }) => {
             Post
           </button>
         </form>
+      )}
+
+      {loading ? (
+        <div>Loading comments…</div>
+      ) : (
+        comments.map((c) => (
+          <div key={c.id} className="flex gap-2">
+            <img
+              src={c.avatarUrl}
+              alt="avatar"
+              className="w-8 h-8 rounded-full object-cover"
+            />
+            <div className="flex-1">
+              <div className="text-sm text-teal-400">@{c.username}</div>
+              <div className="text-sm text-gray-200">{c.text}</div>
+            </div>
+            {user?.id === c.authorId && (
+              <button
+                onClick={() => handleDelete(c.id)}
+                className="text-xs text-red-500 hover:underline"
+              >
+                Delete
+              </button>
+            )}
+          </div>
+        ))
       )}
     </div>
   );

--- a/astrogram/src/components/PostCard/PostCard.tsx
+++ b/astrogram/src/components/PostCard/PostCard.tsx
@@ -135,7 +135,7 @@ const PostCard: React.FC<PostCardProps> = ({
   };
 
   return (
-    <div className="w-full py-0 sm:py-4 sm:px-4">
+    <div className="w-full py-0 sm:py-2 sm:px-2">
       <div className="bg-white dark:bg-gray-800 text-black dark:text-white rounded-2xl shadow-md hover:shadow-xl transition duration-300 overflow-hidden border border-gray-300 dark:border-gray-700 w-full sm:max-w-2xl sm:mx-auto">
 
         {/* Header */}

--- a/astrogram/src/lib/api.tsx
+++ b/astrogram/src/lib/api.tsx
@@ -186,3 +186,12 @@ export async function createComment<T = any>(postId: string, text: string): Prom
   }
   return res.json();
 }
+
+export async function deleteComment(commentId: string): Promise<void> {
+  const res = await apiFetch(`/comments/${commentId}`, {
+    method: 'DELETE',
+  });
+  if (!res.ok) {
+    throw new Error(`Failed to delete comment (${res.status})`);
+  }
+}

--- a/astrogram/src/pages/PostPage.tsx
+++ b/astrogram/src/pages/PostPage.tsx
@@ -63,8 +63,8 @@ const PostPage: React.FC = () => {
   }
 
   return (
-    <div className="w-full py-8 flex justify-center min-h-screen bg-gray-900 py-8 px-4">
-      <div className="w-full max-w-3xl px-0 sm:px-4">
+    <div className="w-full py-4 flex justify-center min-h-screen bg-gray-900 px-2">
+      <div className="w-full max-w-3xl px-0 sm:px-2">
         <PostCard {...post} />
         <Comments postId={post.id} />
       </div>

--- a/backend/src/comments/comments.controller.ts
+++ b/backend/src/comments/comments.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, Post, Body, Param, Req, UseGuards, Logger } from '@nestjs/common';
+import { Controller, Get, Post, Body, Param, Req, UseGuards, Logger, Delete } from '@nestjs/common';
 
 import { JwtAuthGuard } from '../auth/jwt-auth.guard';
 import { OptionalAuthGuard } from '../auth/jwt-optional.guard';
@@ -37,5 +37,14 @@ export class CommentsController {
 
     this.logger.log(`User ${userId} toggling like on comment ${id}`);
     return this.comments.toggleLike(userId, id);
+  }
+
+  @UseGuards(JwtAuthGuard)
+  @Delete('comments/:id')
+  delete(@Req() req: any, @Param('id') id: string) {
+    const userId = req.user.sub as string;
+
+    this.logger.log(`User ${userId} deleting comment ${id}`);
+    return this.comments.deleteComment(userId, id);
   }
 }

--- a/backend/src/comments/comments.service.ts
+++ b/backend/src/comments/comments.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable, Logger, ForbiddenException } from '@nestjs/common';
 
 import { PrismaService } from '../prisma/prisma.service';
 import { CreateCommentDto } from './dto/create-comment.dto';
@@ -70,5 +70,16 @@ export class CommentsService {
 
       throw e;
     }
+  }
+
+  async deleteComment(userId: string, commentId: string) {
+    await this.prisma.commentLike.deleteMany({ where: { commentId } });
+    const { count } = await this.prisma.comment.deleteMany({
+      where: { id: commentId, authorId: userId },
+    });
+    if (count === 0) {
+      throw new ForbiddenException(`Cannot delete comment ${commentId}`);
+    }
+    return { success: true };
   }
 }


### PR DESCRIPTION
## Summary
- adjust PostCard and page layout for larger post display
- move comment form above comment list
- allow users to delete their own comments via API
- expose comment deletion endpoint

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688a4ebdea008327a115b23e0fc7e606