### PR TITLE
Move comment delete to menu & tweak form layout

### DIFF
--- a/astrogram/src/components/Comments/Comments.tsx
+++ b/astrogram/src/components/Comments/Comments.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState, FormEvent } from 'react';
+import { MoreVertical } from 'lucide-react';
 import { useAuth } from '../../contexts/AuthContext';
 import { fetchComments, createComment, deleteComment } from '../../lib/api';
 
@@ -17,6 +18,7 @@ const Comments: React.FC<{ postId: string }> = ({ postId }) => {
   const [comments, setComments] = useState<CommentItem[]>([]);
   const [loading, setLoading] = useState(true);
   const [text, setText] = useState('');
+  const [menuOpenId, setMenuOpenId] = useState<string | null>(null);
 
   useEffect(() => {
     setLoading(true);
@@ -50,17 +52,17 @@ const Comments: React.FC<{ postId: string }> = ({ postId }) => {
   return (
     <div className="mt-4 space-y-4">
       {user && (
-        <form onSubmit={handleSubmit} className="flex gap-2 items-start">
+        <form onSubmit={handleSubmit} className="flex flex-col gap-2">
           <textarea
             value={text}
             onChange={(e) => setText(e.target.value)}
-            className="flex-1 bg-gray-700 text-gray-100 rounded-md p-2"
+            className="w-full bg-gray-700 text-gray-100 rounded-md p-2"
             placeholder="Write a comment..."
             rows={2}
           />
           <button
             type="submit"
-            className="px-3 py-2 bg-purple-600 rounded-md hover:bg-purple-700"
+            className="self-end px-3 py-2 bg-purple-600 rounded-md hover:bg-purple-700"
           >
             Post
           </button>
@@ -71,7 +73,7 @@ const Comments: React.FC<{ postId: string }> = ({ postId }) => {
         <div>Loading comments…</div>
       ) : (
         comments.map((c) => (
-          <div key={c.id} className="flex gap-2">
+          <div key={c.id} className="flex gap-2 relative">
             <img
               src={c.avatarUrl}
               alt="avatar"
@@ -82,12 +84,28 @@ const Comments: React.FC<{ postId: string }> = ({ postId }) => {
               <div className="text-sm text-gray-200">{c.text}</div>
             </div>
             {user?.id === c.authorId && (
-              <button
-                onClick={() => handleDelete(c.id)}
-                className="text-xs text-red-500 hover:underline"
-              >
-                Delete
-              </button>
+              <div className="relative">
+                <button
+                  type="button"
+                  onClick={() => setMenuOpenId(menuOpenId === c.id ? null : c.id)}
+                  className="p-1 text-gray-400 hover:text-gray-600"
+                >
+                  <MoreVertical className="w-4 h-4" />
+                </button>
+                {menuOpenId === c.id && (
+                  <div className="absolute right-0 mt-2 w-28 bg-white dark:bg-gray-800 rounded shadow-lg z-10">
+                    <button
+                      onClick={() => {
+                        handleDelete(c.id);
+                        setMenuOpenId(null);
+                      }}
+                      className="block w-full px-4 py-2 text-sm text-red-500 hover:bg-gray-100 dark:hover:bg-gray-700 text-left"
+                    >
+                      Delete
+                    </button>
+                  </div>
+                )}
+              </div>
             )}
           </div>
         ))


### PR DESCRIPTION
## Summary
- add dropdown menu to comments similar to posts
- remove inline delete button and toggle with three-dot menu
- adjust comment form layout so textarea takes full width and button sits below

## Testing
- `npm test` within `backend`
- `npm run lint` within `astrogram` *(fails: many existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_688a53d4fafc8327892b2156b2177e30