### PR TITLE
Add backend e2e tests

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -89,6 +89,9 @@
       "**/*.(t|j)s"
     ],
     "coverageDirectory": "../coverage",
-    "testEnvironment": "node"
+    "testEnvironment": "node",
+    "moduleNameMapper": {
+      "^src/(.*)$": "<rootDir>/$1"
+    }
   }
 }

--- a/backend/test/app.e2e-spec.ts
+++ b/backend/test/app.e2e-spec.ts
@@ -3,6 +3,22 @@ import { INestApplication } from '@nestjs/common';
 import * as request from 'supertest';
 import { App } from 'supertest/types';
 import { AppModule } from './../src/app.module';
+import { PrismaService } from '../src/prisma/prisma.service';
+import { WeatherService } from '../src/weather/weather.service';
+
+beforeAll(() => {
+  process.env.SUPA_URL = 'http://localhost';
+  process.env.SUPA_SERVICE_KEY = 'key';
+  process.env.FACEBOOK_CLIENT_ID = 'id';
+  process.env.FACEBOOK_CLIENT_SECRET = 'secret';
+  process.env.GOOGLE_CLIENT_ID = 'id';
+  process.env.GOOGLE_CLIENT_SECRET = 'secret';
+  process.env.JWT_SECRET = 'secret';
+  process.env.JWT_REFRESH_SECRET = 'secret';
+  process.env.JWT_EXPIRATION = '1h';
+  process.env.JWT_REFRESH_EXPIRATION = '1h';
+  process.env.BACKEND_URL = 'http://localhost';
+});
 
 describe('AppController (e2e)', () => {
   let app: INestApplication<App>;
@@ -10,7 +26,30 @@ describe('AppController (e2e)', () => {
   beforeEach(async () => {
     const moduleFixture: TestingModule = await Test.createTestingModule({
       imports: [AppModule],
-    }).compile();
+    })
+      .overrideProvider(PrismaService)
+      .useValue({
+        $connect: jest.fn(),
+        $disconnect: jest.fn(),
+      })
+      .overrideProvider(WeatherService)
+      .useValue({
+        fetchVisibility: jest
+          .fn()
+          .mockResolvedValue([{ date: '2024-01-01', conditions: {} }]),
+        fetchAstronomy: jest.fn().mockResolvedValue([
+          {
+            datetime: '2024-01-01',
+            sunrise: '07:00',
+            sunset: '19:00',
+            moonrise: '09:00',
+            moonset: '21:00',
+            moonphase: 0.5,
+          },
+        ]),
+        fetchLocationName: jest.fn().mockResolvedValue('Test City'),
+      })
+      .compile();
 
     app = moduleFixture.createNestApplication();
     await app.init();
@@ -21,5 +60,29 @@ describe('AppController (e2e)', () => {
       .get('/')
       .expect(200)
       .expect('Hello World!');
+  });
+
+  it('/api/weather (POST)', async () => {
+    const res = await request(app.getHttpServer())
+      .post('/api/weather')
+      .send({ latitude: 0, longitude: 0 })
+      .expect(201);
+    expect(res.body).toEqual({
+      status: 'ok',
+      coordinates: 'Test City',
+      data: [
+        {
+          date: '2024-01-01',
+          conditions: {},
+          astro: {
+            sunrise: '07:00',
+            sunset: '19:00',
+            moonrise: '09:00',
+            moonset: '21:00',
+            moonPhase: { phase: 'Full Moon', illumination: 50 },
+          },
+        },
+      ],
+    });
   });
 });

--- a/backend/test/jest-e2e.json
+++ b/backend/test/jest-e2e.json
@@ -5,5 +5,8 @@
   "testRegex": ".e2e-spec.ts$",
   "transform": {
     "^.+\\.(t|j)s$": "ts-jest"
+  },
+  "moduleNameMapper": {
+    "^src/(.*)$": "<rootDir>/../src/$1"
   }
 }


### PR DESCRIPTION
## Summary
- update Jest config to resolve src paths
- override Prisma and Weather services in e2e tests
- add weather endpoint e2e test

## Testing
- `cd backend && npm run test:e2e`

------
https://chatgpt.com/codex/tasks/task_e_688a96dcb788832787dae960e9e4c88a