### PR TITLE
Improve comment interactions

### DIFF
--- a/astrogram/src/components/Comments/Comments.tsx
+++ b/astrogram/src/components/Comments/Comments.tsx
@@ -1,6 +1,6 @@
 
 import { MoreVertical, Star } from 'lucide-react';
-import React, { useEffect, useState,type FormEvent } from 'react';
+import React, { useEffect, useState, type FormEvent } from 'react';
 import { useAuth } from '../../contexts/AuthContext';
 import { fetchComments, createComment, deleteComment, toggleCommentLike } from '../../lib/api';
 
@@ -25,7 +25,7 @@ const Comments: React.FC<{ postId: string }> = ({ postId }) => {
   useEffect(() => {
     setLoading(true);
     fetchComments<CommentItem>(postId)
-      .then((data) => data.map((c) => ({ ...c, likedByMe: false })))
+      .then((data) => data.map((c) => ({ ...c, likedByMe: c.likedByMe ?? false })))
       .then(setComments)
       .catch((e) => console.error(e))
       .finally(() => setLoading(false));
@@ -104,12 +104,12 @@ const Comments: React.FC<{ postId: string }> = ({ postId }) => {
               <button
                 type="button"
                 onClick={() => handleLike(c.id)}
-
-                className="btn-unstyled flex items-center gap-1 mt-1 text-yellow-400 hover:text-yellow-300"
+                className="btn-unstyled relative mt-1 text-yellow-400 hover:text-yellow-300 w-5 h-5 flex items-center justify-center"
               >
                 <Star className="w-4 h-4" fill={c.likedByMe ? 'currentColor' : 'none'} />
-                <span className="text-xs">{c.likes}</span>
-
+                <span className="absolute inset-0 flex items-center justify-center text-[10px] font-semibold">
+                  {c.likes}
+                </span>
               </button>
             </div>
             {user?.id === c.authorId && (

--- a/astrogram/src/components/PostCard/PostCard.tsx
+++ b/astrogram/src/components/PostCard/PostCard.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState, useRef } from "react";
+import { useNavigate } from 'react-router-dom';
 import { formatDistanceToNow } from "date-fns";
 import { Star, MessageCircle, Share2, Repeat2, Bookmark, MoreVertical } from "lucide-react";
 import { likePost, sharePost, repostPost, apiFetch } from '../../lib/api';
@@ -34,11 +35,12 @@ const PostCard: React.FC<PostCardProps> = ({
 }) => {
 
   const { user } = useAuth();
+  const navigate = useNavigate();
   const isOwn = user?.id === authorId;
 
   const [liked, setLiked] = useState(likedByMe);
   const [starCount, setStarCount] = useState(stars);
-  const [commentCount, setCommentCount] = useState(comments);
+  const [commentCount] = useState(comments);
   const [shareCount, setShareCount] = useState(shares);
   const [reposted, setReposted] = useState(false);
   const [saved, setSaved] = useState(false);
@@ -221,7 +223,7 @@ const PostCard: React.FC<PostCardProps> = ({
             {/* Comment */}
             <button
               type="button"
-              onClick={() => setCommentCount(c => c + 1)}
+              onClick={() => navigate(`/posts/${id}`)}
               className="btn-unstyled btn-action hover:text-violet-400"
             >
               <MessageCircle className="w-5 h-5" />

--- a/backend/src/comments/comments.controller.ts
+++ b/backend/src/comments/comments.controller.ts
@@ -14,10 +14,11 @@ export class CommentsController {
 
   @UseGuards(OptionalAuthGuard)
   @Get('posts/:postId/comments')
-  getComments(@Param('postId') postId: string) {
+  getComments(@Req() req: any, @Param('postId') postId: string) {
 
+    const userId = req.user?.sub as string | undefined;
     this.logger.log(`Fetching comments for post ${postId}`);
-    return this.comments.getCommentsForPost(postId);
+    return this.comments.getCommentsForPost(postId, userId);
   }
 
   @UseGuards(JwtAuthGuard)

--- a/backend/src/comments/comments.service.ts
+++ b/backend/src/comments/comments.service.ts
@@ -29,7 +29,7 @@ export class CommentsService {
     return comment;
   }
 
-  async getCommentsForPost(postId: string) {
+  async getCommentsForPost(postId: string, currentUserId?: string) {
 
     this.logger.log(`Fetching comments for post ${postId}`);
 
@@ -38,6 +38,9 @@ export class CommentsService {
       orderBy: { createdAt: 'asc' },
       include: {
         author: { select: { username: true, avatarUrl: true } },
+        likedBy: currentUserId
+          ? { where: { userId: currentUserId }, select: { id: true } }
+          : false,
       },
     });
     return list.map(c => ({
@@ -48,6 +51,7 @@ export class CommentsService {
       avatarUrl: c.author.avatarUrl ?? '',
       timestamp: c.createdAt.toISOString(),
       likes: c.likes,
+      likedByMe: currentUserId ? c.likedBy.length > 0 : false,
     }));
   }
 


### PR DESCRIPTION
## Summary
- persist comment like status across page loads via API
- overlay comment like count on the star icon
- navigate to Post page when comment icon clicked

## Testing
- `npx eslint "src/**/*.ts"` in `backend`
- `npx eslint "src/**/*.{ts,tsx}"` in `astrogram`


------
https://chatgpt.com/codex/tasks/task_e_688a9c7945a483279203997eafdcfc91