### PR TITLE
Fix spacing on stars and comments

### DIFF
--- a/astrogram/src/components/Comments/Comments.tsx
+++ b/astrogram/src/components/Comments/Comments.tsx
@@ -91,7 +91,7 @@ const Comments: React.FC<{ postId: string }> = ({ postId }) => {
         comments.map((c) => (
           <div
             key={c.id}
-            className="flex gap-2 relative border-t border-b border-white/20"
+            className="flex gap-2 py-2 relative border-t border-b border-white/20"
           >
             <img
               src={c.avatarUrl}

--- a/astrogram/src/components/PostCard/PostCard.tsx
+++ b/astrogram/src/components/PostCard/PostCard.tsx
@@ -207,7 +207,7 @@ const PostCard: React.FC<PostCardProps> = ({
               className="btn-unstyled btn-action hover:text-yellow-400"
             >
               <Star className="w-5 h-5" fill={liked ? "currentColor" : "none"} />
-              <span>{starCount}</span>
+              <span className="ml-1">{starCount}</span>
             </button>
 
             {/* Repost */}


### PR DESCRIPTION
## Summary
- align star count next to star icon
- add padding around comments

## Testing
- `npm run lint` (fails: 25 errors, 1 warning)
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688a9f56b30c8327af254f91fc99f27c