### PR TITLE
Add profile page with user content

### DIFF
--- a/astrogram/src/App.tsx
+++ b/astrogram/src/App.tsx
@@ -12,6 +12,7 @@ import CompleteProfilePage from './pages/CompleteProfilePage'
 import { RequireProfileCompletion } from "./components/auth/RequireProfileCompletion";
 import PostPage from './pages/PostPage'
 import NotificationsPage from './pages/NotificationsPage'
+import ProfilePage from './pages/ProfilePage'
 
 
 
@@ -49,8 +50,9 @@ const App: React.FC = () => {
       <Route path="/notifications" element={<NotificationsPage />} />
 
           <Route element={<RequireProfileCompletion />}>
-            <Route path="/upload" element={<UploadForm />} />
-            <Route path="/completeProfile" element={<CompleteProfilePage />} />
+          <Route path="/upload" element={<UploadForm />} />
+          <Route path="/completeProfile" element={<CompleteProfilePage />} />
+          <Route path="/profile" element={<ProfilePage />} />
 
 
             <Route

--- a/astrogram/src/components/Navbar/Navbar.tsx
+++ b/astrogram/src/components/Navbar/Navbar.tsx
@@ -76,7 +76,7 @@ const Navbar = () => {
               </span>
             )}
           </Link>
-          <Link to="/signup" className="btn-unstyled" aria-label="Account">
+          <Link to={user ? '/profile' : '/signup'} className="btn-unstyled" aria-label="Account">
           {user?.avatarUrl ? (
             <img
               src={user.avatarUrl}

--- a/astrogram/src/lib/api.tsx
+++ b/astrogram/src/lib/api.tsx
@@ -230,3 +230,29 @@ export async function fetchUnreadCount(): Promise<number> {
   const data = await res.json();
   return data.count as number;
 }
+
+// --------------------------------------------------
+// Profile helpers
+
+export async function fetchMyPosts<T = any>(): Promise<T[]> {
+  const res = await apiFetch('/users/me/posts');
+  return res.json();
+}
+
+export async function fetchMyComments<T = any>(): Promise<T[]> {
+  const res = await apiFetch('/users/me/comments');
+  return res.json();
+}
+
+export async function updateAvatar(username: string, file: File) {
+  const form = new FormData();
+  form.append('username', username);
+  form.append('avatar', file);
+  const res = await apiFetch('/users/me', { method: 'PUT', body: form });
+  return res.json();
+}
+
+export async function deleteProfile() {
+  const res = await apiFetch('/users/me', { method: 'DELETE' });
+  return res.json();
+}

--- a/astrogram/src/pages/ProfilePage.tsx
+++ b/astrogram/src/pages/ProfilePage.tsx
@@ -1,0 +1,134 @@
+import React, { useEffect, useState } from 'react';
+import PostCard, { type PostCardProps } from '../components/PostCard/PostCard';
+import { useAuth } from '../contexts/AuthContext';
+import { useNavigate } from 'react-router-dom';
+import {
+  fetchMyPosts,
+  fetchMyComments,
+  updateAvatar,
+  deleteProfile,
+} from '../lib/api';
+
+interface CommentItem {
+  id: string;
+  text: string;
+  authorId: string;
+  username: string;
+  avatarUrl: string;
+  timestamp: string;
+  likes: number;
+  likedByMe?: boolean;
+}
+
+const ProfilePage: React.FC = () => {
+  const { user, logout } = useAuth();
+  const navigate = useNavigate();
+  const [active, setActive] = useState<'posts' | 'comments' | 'profile'>('posts');
+  const [posts, setPosts] = useState<PostCardProps[]>([]);
+  const [comments, setComments] = useState<CommentItem[]>([]);
+  const [avatarFile, setAvatarFile] = useState<File | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    fetchMyPosts<PostCardProps>()
+      .then(setPosts)
+      .catch(() => {})
+      .finally(() => setLoading(false));
+    fetchMyComments<CommentItem>()
+      .then(setComments)
+      .catch(() => {});
+  }, []);
+
+  if (!user) return <div className="p-4">Please sign in.</div>;
+
+  const handleAvatarChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const f = e.target.files?.[0];
+    if (f) setAvatarFile(f);
+  };
+
+  const handleAvatarUpload = async () => {
+    if (!avatarFile) return;
+    await updateAvatar(user.username || '', avatarFile);
+    window.location.reload();
+  };
+
+  const handleDelete = async () => {
+    if (!confirm('Delete your account? This cannot be undone.')) return;
+    await deleteProfile();
+    logout();
+    navigate('/signup');
+  };
+
+  return (
+    <div className="p-4 max-w-2xl mx-auto text-gray-200">
+      <div className="flex space-x-4 mb-4">
+        <button
+          onClick={() => setActive('posts')}
+          className={`px-3 py-1 rounded ${active === 'posts' ? 'bg-purple-600' : 'bg-gray-700'}`}
+        >
+          Posts
+        </button>
+        <button
+          onClick={() => setActive('comments')}
+          className={`px-3 py-1 rounded ${active === 'comments' ? 'bg-purple-600' : 'bg-gray-700'}`}
+        >
+          Comments
+        </button>
+        <button
+          onClick={() => setActive('profile')}
+          className={`px-3 py-1 rounded ${active === 'profile' ? 'bg-purple-600' : 'bg-gray-700'}`}
+        >
+          Profile
+        </button>
+      </div>
+
+      {active === 'posts' && (
+        <div className="space-y-4">
+          {loading ? (
+            <div>Loading…</div>
+          ) : (
+            posts.map((p) => <PostCard key={p.id} {...p} />)
+          )}
+        </div>
+      )}
+
+      {active === 'comments' && (
+        <ul className="space-y-4">
+          {comments.map((c) => (
+            <li key={c.id} className="border-b border-white/20 pb-2">
+              <div className="text-teal-400 text-sm">@{c.username}</div>
+              <div className="text-sm">{c.text}</div>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      {active === 'profile' && (
+        <div className="space-y-4">
+          <div className="flex items-center space-x-4">
+            <img
+              src={user.avatarUrl}
+              alt="avatar"
+              className="w-20 h-20 rounded-full object-cover"
+            />
+            <input type="file" accept="image/*" onChange={handleAvatarChange} />
+            <button
+              onClick={handleAvatarUpload}
+              className="px-3 py-1 bg-purple-600 rounded"
+            >
+              Change Picture
+            </button>
+          </div>
+          <button
+            onClick={handleDelete}
+            className="px-3 py-1 bg-red-600 rounded"
+          >
+            Delete Profile
+          </button>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default ProfilePage;

--- a/backend/src/users/users.controller.ts
+++ b/backend/src/users/users.controller.ts
@@ -1,5 +1,5 @@
 // src/users/users.controller.ts
-import { Controller, Get, Req, UseGuards, Logger, Put, UseInterceptors, UploadedFile, InternalServerErrorException, Body } from '@nestjs/common';
+import { Controller, Get, Req, UseGuards, Logger, Put, UseInterceptors, UploadedFile, InternalServerErrorException, Body, Delete } from '@nestjs/common';
 import { JwtAuthGuard }                             from '../auth/jwt-auth.guard';
 import { UsersService }                             from './users.service';
 import type { Request }                             from 'express';
@@ -74,5 +74,24 @@ export class UsersController {
       this.logger.error(`Error in PUT /api/users/me: ${err.message}`, err.stack);
       throw new InternalServerErrorException('Could not update profile');
     }
+  }
+
+  @Get('me/posts')
+  @UseGuards(JwtAuthGuard)
+  getMyPosts(@Req() req: Request & { user: { sub: string } }) {
+    return this.usersService.getPostsByUser(req.user.sub);
+  }
+
+  @Get('me/comments')
+  @UseGuards(JwtAuthGuard)
+  getMyComments(@Req() req: Request & { user: { sub: string } }) {
+    return this.usersService.getCommentsByUser(req.user.sub);
+  }
+
+  @Delete('me')
+  @UseGuards(JwtAuthGuard)
+  async deleteMe(@Req() req: Request & { user: { sub: string } }) {
+    await this.usersService.deleteUser(req.user.sub);
+    return { success: true };
   }
 }


### PR DESCRIPTION
## Summary
- create `ProfilePage` with tabs for posts, comments and profile management
- link avatar in navbar to new profile page
- expose profile-related API helpers
- expose backend endpoints for user posts/comments and delete account

## Testing
- `npm test` in `backend`
- `npm run lint` *(fails: Unsafe member access errors)*

------
https://chatgpt.com/codex/tasks/task_e_688aa18131e48327b3bb3cbd92c03eee