### PR TITLE
Fix profile tab and star styles

### DIFF
--- a/astrogram/src/components/Comments/Comments.tsx
+++ b/astrogram/src/components/Comments/Comments.tsx
@@ -104,7 +104,7 @@ const Comments: React.FC<{ postId: string }> = ({ postId }) => {
               <button
                 type="button"
                 onClick={() => handleLike(c.id)}
-                className="btn-unstyled btn-action mt-1 text-yellow-400 hover:text-yellow-300"
+                className="btn-unstyled btn-action mt-1 text-white hover:text-gray-300"
               >
                 <Star className="w-4 h-4" fill={c.likedByMe ? 'currentColor' : 'none'} />
                 <span className="ml-1 text-xs">{c.likes}</span>

--- a/astrogram/src/components/PostCard/PostCard.tsx
+++ b/astrogram/src/components/PostCard/PostCard.tsx
@@ -204,7 +204,7 @@ const PostCard: React.FC<PostCardProps> = ({
             <button
               type="button"
               onClick={handleLike}
-              className="btn-unstyled btn-action hover:text-yellow-400"
+              className="btn-unstyled btn-action text-white hover:text-gray-300"
             >
               <Star className="w-5 h-5" fill={liked ? "currentColor" : "none"} />
               <span className="ml-1">{starCount}</span>

--- a/astrogram/src/pages/ProfilePage.tsx
+++ b/astrogram/src/pages/ProfilePage.tsx
@@ -96,30 +96,30 @@ const ProfilePage: React.FC = () => {
         <nav className="-mb-px flex justify-center space-x-8" aria-label="Profile tabs">
           <Link
             to="/profile/posts"
-            className={`whitespace-nowrap py-4 px-1 border-b-2 font-bold text-sm transition-colors duration-200 ${
+            className={`whitespace-nowrap py-2 px-1 border-b-2 font-bold text-sm hover:no-underline transition-colors duration-200 ${
               active === 'posts'
-                ? 'border-purple-500 text-purple-400'
-                : 'border-transparent text-gray-400 hover:text-gray-200 hover:border-gray-200'
+                ? 'border-purple-500 text-white'
+                : 'border-transparent text-white hover:text-gray-300 hover:border-gray-300'
             }`}
           >
             Posts
           </Link>
           <Link
             to="/profile/comments"
-            className={`whitespace-nowrap py-4 px-1 border-b-2 font-bold text-sm transition-colors duration-200 ${
+            className={`whitespace-nowrap py-2 px-1 border-b-2 font-bold text-sm hover:no-underline transition-colors duration-200 ${
               active === 'comments'
-                ? 'border-purple-500 text-purple-400'
-                : 'border-transparent text-gray-400 hover:text-gray-200 hover:border-gray-200'
+                ? 'border-purple-500 text-white'
+                : 'border-transparent text-white hover:text-gray-300 hover:border-gray-300'
             }`}
           >
             Comments
           </Link>
           <Link
             to="/profile/me"
-            className={`whitespace-nowrap py-4 px-1 border-b-2 font-bold text-sm transition-colors duration-200 ${
+            className={`whitespace-nowrap py-2 px-1 border-b-2 font-bold text-sm hover:no-underline transition-colors duration-200 ${
               active === 'profile'
-                ? 'border-purple-500 text-purple-400'
-                : 'border-transparent text-gray-400 hover:text-gray-200 hover:border-gray-200'
+                ? 'border-purple-500 text-white'
+                : 'border-transparent text-white hover:text-gray-300 hover:border-gray-300'
             }`}
           >
             Profile
@@ -156,7 +156,7 @@ const ProfilePage: React.FC = () => {
                   <button
                     type="button"
                     onClick={() => handleLike(c.id)}
-                    className="mr-2 flex items-center text-yellow-400 hover:text-yellow-300"
+                    className="mr-2 flex items-center text-white hover:text-gray-300"
                   >
                     <Star
                       className="w-4 h-4"


### PR DESCRIPTION
## Summary
- update profile tab colors and spacing
- standardize star icons to white

## Testing
- `npm --prefix astrogram run lint` *(fails: 27 errors, 1 warning)*

------
https://chatgpt.com/codex/tasks/task_e_688aae2d2bf8832798f3aedb750192af