### PR TITLE
Improve notification layout

### DIFF
--- a/astrogram/src/components/Navbar/Navbar.tsx
+++ b/astrogram/src/components/Navbar/Navbar.tsx
@@ -71,7 +71,9 @@ const Navbar = () => {
           <Link to="/notifications" className="relative btn-unstyled" aria-label="Notifications">
             <Bell className="w-6 h-6" />
             {count > 0 && (
-              <span className="absolute -top-1 -right-1 bg-red-500 text-xs rounded-full w-5 h-5 flex items-center justify-center">
+              <span
+                className="absolute top-0 right-0 transform translate-x-1/2 -translate-y-1/2 bg-red-500 text-xs rounded-full w-5 h-5 flex items-center justify-center"
+              >
                 {count}
               </span>
             )}

--- a/astrogram/src/pages/NotificationsPage.tsx
+++ b/astrogram/src/pages/NotificationsPage.tsx
@@ -27,7 +27,11 @@ const NotificationsPage: React.FC = () => {
         <ul className="space-y-4">
           {items.map((n) => (
             <li key={n.id} className="flex gap-2 border-b border-white/20 pb-2">
-              <img src={n.actor.avatarUrl} alt="avatar" className="w-8 h-8 rounded-full object-cover" />
+              <img
+                src={n.actor.avatarUrl}
+                alt="avatar"
+                className="w-8 h-8 rounded-full object-cover"
+              />
               <div className="text-sm">
                 <span className="text-teal-400">@{n.actor.username}</span>{' '}
                 {n.type === 'COMMENT'
@@ -35,6 +39,17 @@ const NotificationsPage: React.FC = () => {
                   : n.type === 'POST_LIKE'
                   ? 'liked your post'
                   : 'liked your comment'}
+                {n.postId && (
+                  <>
+                    {' '}
+                    <a
+                      href={`/posts/${n.postId}`}
+                      className="underline text-teal-300 hover:text-teal-200"
+                    >
+                      View post
+                    </a>
+                  </>
+                )}
               </div>
             </li>
           ))}


### PR DESCRIPTION
## Summary
- adjust notification badge positioning in Navbar
- allow notifications to link to posts

## Testing
- `npm --prefix astrogram run lint` *(fails: 28 problems)*
- `npm --prefix backend test`

------
https://chatgpt.com/codex/tasks/task_e_688b96f850088327b504bb270ee0a44d