### PR TITLE
Add post page skeletons

### DIFF
--- a/astrogram/src/components/Comments/Comments.tsx
+++ b/astrogram/src/components/Comments/Comments.tsx
@@ -3,6 +3,7 @@ import { MoreVertical, Star } from 'lucide-react';
 import React, { useEffect, useState, type FormEvent } from 'react';
 import { useAuth } from '../../contexts/AuthContext';
 import { fetchComments, createComment, deleteComment, toggleCommentLike } from '../../lib/api';
+import CommentsSkeleton from './CommentsSkeleton';
 
 export interface CommentItem {
   id: string;
@@ -86,7 +87,7 @@ const Comments: React.FC<{ postId: string }> = ({ postId }) => {
       )}
 
       {loading ? (
-        <div>Loading comments…</div>
+        <CommentsSkeleton />
       ) : (
         comments.map((c) => (
           <div

--- a/astrogram/src/components/Comments/CommentsSkeleton.tsx
+++ b/astrogram/src/components/Comments/CommentsSkeleton.tsx
@@ -1,0 +1,23 @@
+import React from 'react'
+
+const CommentsSkeleton: React.FC<{ count?: number }> = ({ count = 3 }) => {
+  return (
+    <div className="mt-4 space-y-2 animate-pulse">
+      {Array.from({ length: count }).map((_, i) => (
+        <div
+          key={i}
+          className="flex gap-2 py-2 border-t border-b border-white/20"
+        >
+          <div className="w-8 h-8 bg-gray-700 rounded-full" />
+          <div className="flex-1 space-y-1">
+            <div className="h-3 w-1/4 bg-gray-700 rounded" />
+            <div className="h-4 w-full bg-gray-700 rounded" />
+            <div className="h-3 w-10 bg-gray-700 rounded" />
+          </div>
+        </div>
+      ))}
+    </div>
+  )
+}
+
+export default CommentsSkeleton

--- a/astrogram/src/pages/PostPage.tsx
+++ b/astrogram/src/pages/PostPage.tsx
@@ -1,8 +1,10 @@
 import React, { useEffect, useState } from 'react'
 import { useParams, useNavigate } from 'react-router-dom'
 
-import PostCard, { type PostCardProps }      from '../components/PostCard/PostCard'
-import Comments                           from '../components/Comments/Comments'
+import PostCard, { type PostCardProps } from '../components/PostCard/PostCard'
+import PostSkeleton                     from '../components/PostCard/PostSkeleton'
+import Comments                         from '../components/Comments/Comments'
+import CommentsSkeleton                 from '../components/Comments/CommentsSkeleton'
 import { apiFetch }                     from '../lib/api'
 
 interface FullPost extends PostCardProps {
@@ -53,7 +55,14 @@ const PostPage: React.FC = () => {
   }, [id, nav])
 
   if (loading) {
-    return <div className="p-8 text-center">Loading post…</div>
+    return (
+      <div className="w-full py-4 flex justify-center min-h-screen bg-gray-900 px-2">
+        <div className="w-full max-w-3xl px-0 sm:px-2 space-y-4">
+          <PostSkeleton />
+          <CommentsSkeleton />
+        </div>
+      </div>
+    )
   }
   if (error) {
     return <div className="p-8 text-center text-red-500">{error}</div>


### PR DESCRIPTION
## Summary
- show `PostSkeleton` and `CommentsSkeleton` while loading post page
- create `CommentsSkeleton` component for comment loading placeholder
- use `CommentsSkeleton` inside comments component

## Testing
- `npm run lint` *(fails: many pre-existing lint errors)*
- `npm test` in backend


------
https://chatgpt.com/codex/tasks/task_e_688bae422e2c8327918ea52360b061b5