### PR TITLE
Enable public user profiles

### DIFF
--- a/astrogram/src/App.tsx
+++ b/astrogram/src/App.tsx
@@ -13,6 +13,7 @@ import { RequireProfileCompletion } from "./components/auth/RequireProfileComple
 import PostPage from './pages/PostPage'
 import NotificationsPage from './pages/NotificationsPage'
 import ProfilePage from './pages/ProfilePage'
+import UserPage from './pages/UserPage'
 
 
 
@@ -48,6 +49,9 @@ const App: React.FC = () => {
         {/* single-post detail view */}
       <Route path="/posts/:id" element={<PostPage />} />
       <Route path="/notifications" element={<NotificationsPage />} />
+
+      <Route path="/users/:username" element={<UserPage />} />
+      <Route path="/users/:username/:tab" element={<UserPage />} />
 
           <Route element={<RequireProfileCompletion />}>
           <Route path="/upload" element={<UploadForm />} />

--- a/astrogram/src/components/Comments/Comments.tsx
+++ b/astrogram/src/components/Comments/Comments.tsx
@@ -1,6 +1,7 @@
 
 import { MoreVertical, Star } from 'lucide-react';
 import React, { useEffect, useState, type FormEvent } from 'react';
+import { Link } from 'react-router-dom';
 import { useAuth } from '../../contexts/AuthContext';
 import { fetchComments, createComment, deleteComment, toggleCommentLike } from '../../lib/api';
 
@@ -99,7 +100,7 @@ const Comments: React.FC<{ postId: string }> = ({ postId }) => {
               className="w-8 h-8 rounded-full object-cover"
             />
             <div className="flex-1">
-              <div className="text-sm text-teal-400">@{c.username}</div>
+              <Link to={`/users/${c.username}/posts`} className="text-sm text-teal-400 hover:underline">@{c.username}</Link>
               <div className="text-sm text-gray-200">{c.text}</div>
               <button
                 type="button"

--- a/astrogram/src/components/PostCard/PostCard.tsx
+++ b/astrogram/src/components/PostCard/PostCard.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState, useRef } from "react";
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, Link } from 'react-router-dom';
 import { formatDistanceToNow } from "date-fns";
 import { Star, MessageCircle, Share2, Repeat2, Bookmark, MoreVertical } from "lucide-react";
 import { likePost, sharePost, repostPost, apiFetch } from '../../lib/api';
@@ -142,14 +142,14 @@ const PostCard: React.FC<PostCardProps> = ({
 
         {/* Header */}
         <div className="px-4 sm:px-6 py-4 border-b border-gray-200 dark:border-gray-700 flex justify-between items-center">
-          <div className="flex items-center gap-2">
+          <Link to={`/users/${username}/posts`} className="flex items-center gap-2 hover:underline">
             <img
               src={avatarUrl}
               alt={`${username}'s profile`}
               className="w-8 h-8 rounded-full object-cover"
             />
             <span className="font-semibold text-teal-400 text-sm">@{username}</span>
-          </div>
+          </Link>
           <div className="flex items-center gap-2">
             {timestamp && (
               <span className="text-xs text-gray-500 dark:text-gray-400">

--- a/astrogram/src/lib/api.tsx
+++ b/astrogram/src/lib/api.tsx
@@ -244,6 +244,21 @@ export async function fetchMyComments<T = any>(): Promise<T[]> {
   return res.json();
 }
 
+export async function fetchUser(username: string) {
+  const res = await apiFetch(`/users/${username}`);
+  return res.json();
+}
+
+export async function fetchUserPosts<T = any>(username: string): Promise<T[]> {
+  const res = await apiFetch(`/users/${username}/posts`);
+  return res.json();
+}
+
+export async function fetchUserComments<T = any>(username: string): Promise<T[]> {
+  const res = await apiFetch(`/users/${username}/comments`);
+  return res.json();
+}
+
 export async function updateAvatar(username: string, file: File) {
   const form = new FormData();
   form.append('username', username);

--- a/astrogram/src/pages/ProfilePage.tsx
+++ b/astrogram/src/pages/ProfilePage.tsx
@@ -155,7 +155,7 @@ const ProfilePage: React.FC = () => {
                 className="w-8 h-8 rounded-full object-cover"
               />
               <div className="flex-1">
-                <div className="text-sm text-teal-400">@{c.username}</div>
+                <Link to={`/users/${c.username}/posts`} className="text-sm text-teal-400 hover:underline">@{c.username}</Link>
                 <div className="text-sm text-gray-200">{c.text}</div>
                 <div className="flex items-center text-xs text-gray-400 mt-1">
                   <button

--- a/astrogram/src/pages/UserPage.tsx
+++ b/astrogram/src/pages/UserPage.tsx
@@ -1,0 +1,158 @@
+import React, { useEffect, useState } from 'react';
+import { formatDistanceToNow } from 'date-fns';
+import { Star } from 'lucide-react';
+import PostCard, { type PostCardProps } from '../components/PostCard/PostCard';
+import { useAuth } from '../contexts/AuthContext';
+import { Link, useParams } from 'react-router-dom';
+import {
+  fetchUserPosts,
+  fetchUserComments,
+  toggleCommentLike,
+  fetchUser,
+} from '../lib/api';
+
+interface CommentItem {
+  id: string;
+  text: string;
+  authorId: string;
+  username: string;
+  avatarUrl: string;
+  timestamp: string;
+  likes: number;
+  likedByMe?: boolean;
+}
+
+interface UserInfo {
+  username: string;
+  avatarUrl?: string;
+}
+
+const UserPage: React.FC = () => {
+  const { user } = useAuth();
+  const { username = '', tab } = useParams<{ username: string; tab?: string }>();
+  const active: 'posts' | 'comments' = tab === 'comments' ? 'comments' : 'posts';
+  const [info, setInfo] = useState<UserInfo | null>(null);
+  const [posts, setPosts] = useState<PostCardProps[]>([]);
+  const [comments, setComments] = useState<CommentItem[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    if (!username) return;
+    fetchUser(username).then(setInfo).catch(() => {});
+    fetchUserPosts<PostCardProps>(username)
+      .then(setPosts)
+      .catch(() => {})
+      .finally(() => setLoading(false));
+    fetchUserComments<CommentItem>(username)
+      .then(setComments)
+      .catch(() => {});
+  }, [username]);
+
+  const handleLike = async (id: string) => {
+    try {
+      const { liked, count } = await toggleCommentLike(id);
+      setComments((cs) =>
+        cs.map((c) => (c.id === id ? { ...c, likes: count, likedByMe: liked } : c))
+      );
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
+  return (
+    <div className="p-4 max-w-2xl mx-auto text-gray-200">
+      {info && (
+        <div className="flex items-center space-x-2 mb-4">
+          <img
+            src={info.avatarUrl}
+            alt="avatar"
+            className="w-12 h-12 rounded-full object-cover"
+          />
+          <h2 className="text-lg font-bold">@{info.username}</h2>
+        </div>
+      )}
+      <div className="border-b border-gray-700 mb-4 pt-4">
+        <nav className="-mb-px flex justify-center space-x-8" aria-label="User tabs">
+          <Link
+            to={`/users/${username}/posts`}
+            className={`whitespace-nowrap py-2 px-1 border-b-2 font-bold text-sm hover:no-underline transition-colors duration-200 ${
+              active === 'posts'
+                ? 'border-brand text-white'
+                : 'border-transparent text-white hover:text-gray-300 hover:border-gray-300'
+            }`}
+          >
+            Posts
+          </Link>
+          <Link
+            to={`/users/${username}/comments`}
+            className={`whitespace-nowrap py-2 px-1 border-b-2 font-bold text-sm hover:no-underline transition-colors duration-200 ${
+              active === 'comments'
+                ? 'border-brand text-white'
+                : 'border-transparent text-white hover:text-gray-300 hover:border-gray-300'
+            }`}
+          >
+            Comments
+          </Link>
+        </nav>
+      </div>
+      {active === 'posts' && (
+        <div className="space-y-4">
+          {loading ? (
+            <div>Loading…</div>
+          ) : (
+            posts.map((p) => <PostCard key={p.id} {...p} />)
+          )}
+        </div>
+      )}
+      {active === 'comments' && (
+        <ul className="space-y-4">
+          {comments.length === 0 && (
+            <li className="text-center text-gray-400">No comments yet.</li>
+          )}
+          {comments.map((c) => (
+            <li key={c.id} className="flex gap-2 border-b border-white/20 pb-2">
+              <img
+                src={c.avatarUrl}
+                alt="avatar"
+                className="w-8 h-8 rounded-full object-cover"
+              />
+              <div className="flex-1">
+                <div className="text-sm text-teal-400">@{c.username}</div>
+                <div className="text-sm text-gray-200">{c.text}</div>
+                {user && (
+                  <div className="flex items-center text-xs text-gray-400 mt-1">
+                    <button
+                      type="button"
+                      onClick={() => handleLike(c.id)}
+                      className="mr-2 flex items-center text-white hover:text-gray-300"
+                    >
+                      <Star
+                        className="w-4 h-4"
+                        fill={c.likedByMe ? 'currentColor' : 'none'}
+                      />
+                      <span className="ml-1">{c.likes}</span>
+                    </button>
+                    <span>
+                      {formatDistanceToNow(new Date(c.timestamp), { addSuffix: true })}
+                    </span>
+                  </div>
+                )}
+                {!user && (
+                  <div className="flex items-center text-xs text-gray-400 mt-1">
+                    <Star className="w-4 h-4" fill="none" />
+                    <span className="ml-1">{c.likes}</span>
+                    <span className="ml-2">
+                      {formatDistanceToNow(new Date(c.timestamp), { addSuffix: true })}
+                    </span>
+                  </div>
+                )}
+              </div>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+};
+
+export default UserPage;

--- a/backend/src/users/users.controller.ts
+++ b/backend/src/users/users.controller.ts
@@ -1,5 +1,5 @@
 // src/users/users.controller.ts
-import { Controller, Get, Req, UseGuards, Logger, Put, UseInterceptors, UploadedFile, InternalServerErrorException, Body, Delete } from '@nestjs/common';
+import { Controller, Get, Req, UseGuards, Logger, Put, UseInterceptors, UploadedFile, InternalServerErrorException, Body, Delete, Param } from '@nestjs/common';
 import { JwtAuthGuard }                             from '../auth/jwt-auth.guard';
 import { UsersService }                             from './users.service';
 import type { Request }                             from 'express';
@@ -93,5 +93,20 @@ export class UsersController {
   async deleteMe(@Req() req: Request & { user: { sub: string } }) {
     await this.usersService.deleteUser(req.user.sub);
     return { success: true };
+  }
+
+  @Get(':username/posts')
+  getUserPosts(@Param('username') username: string) {
+    return this.usersService.getPostsByUsername(username);
+  }
+
+  @Get(':username/comments')
+  getUserComments(@Param('username') username: string) {
+    return this.usersService.getCommentsByUsername(username);
+  }
+
+  @Get(':username')
+  getUser(@Param('username') username: string) {
+    return this.usersService.findByUsername(username);
   }
 }


### PR DESCRIPTION
## Summary
- fetch user profiles, posts and comments by username
- link usernames to user profile pages
- show other users' posts/comments on new UserPage
- add backend endpoints for public profile info

## Testing
- `npm --prefix astrogram run lint` *(fails: 29 errors)*
- `npm --prefix backend run lint` *(fails: 146 errors)*
- `npm --prefix backend test`

------
https://chatgpt.com/codex/tasks/task_e_688bb0172a1483279197fb59e2dba09d