### PR TITLE
Add image file filter options

### DIFF
--- a/backend/src/posts/post.controller.ts
+++ b/backend/src/posts/post.controller.ts
@@ -57,7 +57,16 @@ export class PostsController {
     }
 
     @UseGuards(JwtAuthGuard)
-    @UseInterceptors(FileInterceptor('image'))
+    @UseInterceptors(
+        FileInterceptor('image', {
+            fileFilter: (_req, file, cb) => {
+                const allowed = ['image/jpeg', 'image/png', 'image/gif']
+                if (allowed.includes(file.mimetype)) cb(null, true)
+                else cb(new Error('Invalid file type'), false)
+            },
+            limits: { fileSize: 5 * 1024 * 1024 }, // optional 5MB limit
+        }),
+    )
     @Post()
     async createPost(
         @Req() req: any,

--- a/backend/src/users/users.controller.ts
+++ b/backend/src/users/users.controller.ts
@@ -46,7 +46,16 @@ export class UsersController {
 
   @Put('me')
   @UseGuards(JwtAuthGuard)
-  @UseInterceptors(FileInterceptor('avatar'))
+  @UseInterceptors(
+    FileInterceptor('avatar', {
+      fileFilter: (_req, file, cb) => {
+        const allowed = ['image/jpeg', 'image/png', 'image/gif'];
+        if (allowed.includes(file.mimetype)) cb(null, true);
+        else cb(new Error('Invalid file type'), false);
+      },
+      limits: { fileSize: 5 * 1024 * 1024 }, // optional 5MB limit
+    }),
+  )
   async updateProfile(
     @Req() req: Request & { user: { sub: string; email: string } },
     @Body("username") username: string,


### PR DESCRIPTION
## Summary
- validate uploads in `PostsController` and `UsersController`
- restrict mimetypes to standard image formats
- set optional 5 MB file size limit

## Testing
- `cd backend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_688bbe4259d88327b5eeb3b7d9e3948a