### PR TITLE
Add client file type validation

### DIFF
--- a/astrogram/src/components/UploadForm/UploadForm.tsx
+++ b/astrogram/src/components/UploadForm/UploadForm.tsx
@@ -25,7 +25,14 @@ const UploadForm: React.FC = () => {
   }, [file])
 
   const handleFileChange = (e: ChangeEvent<HTMLInputElement>) => {
-    setFile(e.target.files?.[0] ?? null)
+    const f = e.target.files?.[0] ?? null
+    if (f && !f.type.startsWith('image/')) {
+      setError('Only image files are allowed.')
+      setFile(null)
+      return
+    }
+    setError(null)
+    setFile(f)
   }
 
   const handleSubmit = async (e: FormEvent) => {

--- a/astrogram/src/pages/CompleteProfilePage.tsx
+++ b/astrogram/src/pages/CompleteProfilePage.tsx
@@ -31,9 +31,18 @@ const CompleteProfilePage: React.FC = () => {
 
     if (!files || files.length === 0) return;
     const f = files[0];
+    if (!f.type.startsWith('image/')) {
+      setError('Only image files are allowed.');
+      setImageFile(null);
+      setSelectedFile(null);
+      setPreviewUrl('');
+      return;
+    }
+    setError(null);
     setImageFile(f);
+    setSelectedFile(f);
     const url = URL.createObjectURL(f);
-         setPreviewUrl(url);
+    setPreviewUrl(url);
   };
 
   const handleSubmit = async (e: FormEvent) => {

--- a/astrogram/src/pages/ProfilePage.tsx
+++ b/astrogram/src/pages/ProfilePage.tsx
@@ -34,6 +34,7 @@ const ProfilePage: React.FC = () => {
   const [comments, setComments] = useState<CommentItem[]>([]);
   const [avatarFile, setAvatarFile] = useState<File | null>(null);
   const [previewUrl, setPreviewUrl] = useState<string | null>(null);
+  const [avatarError, setAvatarError] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
   const [showConfirm, setShowConfirm] = useState(false);
 
@@ -58,11 +59,17 @@ const ProfilePage: React.FC = () => {
 
   const handleAvatarChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
     const f = e.target.files?.[0];
-    if (f) {
-      setAvatarFile(f);
-      const url = URL.createObjectURL(f);
-      setPreviewUrl(url);
+    if (!f) return;
+    if (!f.type.startsWith('image/')) {
+      setAvatarError('Only image files are allowed.');
+      setAvatarFile(null);
+      setPreviewUrl(null);
+      return;
     }
+    setAvatarError(null);
+    setAvatarFile(f);
+    const url = URL.createObjectURL(f);
+    setPreviewUrl(url);
   };
 
   const handleAvatarUpload = async () => {
@@ -211,6 +218,9 @@ const ProfilePage: React.FC = () => {
                 onChange={handleAvatarChange}
               />
             </label>
+            {avatarError && (
+              <p className="text-red-500 text-sm mt-2">{avatarError}</p>
+            )}
             <button
               onClick={handleAvatarUpload}
               className="px-3 py-1 bg-brand hover:bg-brand-dark rounded"


### PR DESCRIPTION
## Summary
- validate image type in file upload form
- validate avatar upload types in profile and completion pages
- show avatar error message in profile page

## Testing
- `npm run lint` *(fails: 28 errors)*
- `npm test` in backend
- `npm run build` in `astrogram`

------
https://chatgpt.com/codex/tasks/task_e_688bc9633f048327ac493dc22ebd0ac3