### PR TITLE
Fix feed menu not clickable

### DIFF
--- a/astrogram/src/components/PostCard/PostCard.tsx
+++ b/astrogram/src/components/PostCard/PostCard.tsx
@@ -157,8 +157,9 @@ const PostCard: React.FC<PostCardProps> = ({
               </span>
             )}
             {isOwn && (
-              <div ref={menuRef} className="relative">
+              <div ref={menuRef} className="relative" onClick={stop}>
                 <button
+                  type="button"
                   onClick={() => setMenuOpen((o) => !o)}
                   className="p-1 text-gray-400 hover:text-gray-600"
                 >


### PR DESCRIPTION
## Summary
- stop event propagation from vertical menu in `PostCard`

## Testing
- `npm run lint` *(fails: 28 errors, 1 warning)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688bcbf5c07c83279798cca76d8e4a66