### PR TITLE
Redirect to sign in if not authenticated

### DIFF
--- a/astrogram/src/components/Navbar/Navbar.tsx
+++ b/astrogram/src/components/Navbar/Navbar.tsx
@@ -68,7 +68,11 @@ const Navbar = () => {
 
         {/* Right Section */}
         <div className="flex items-center gap-5">
-          <Link to="/notifications" className="relative btn-unstyled" aria-label="Notifications">
+          <Link
+            to={user ? '/notifications' : '/signup'}
+            className="relative btn-unstyled"
+            aria-label="Notifications"
+          >
             <Bell className="w-6 h-6" />
             {count > 0 && (
               <span


### PR DESCRIPTION
## Summary
- ensure the notifications link sends unauthenticated users to the signup page

## Testing
- `npm test --silent` in `backend`
- `npm run lint --silent` in `astrogram` *(fails: 28 errors)*
- `npm run lint --silent` in `backend` *(fails: 146 errors)*

------
https://chatgpt.com/codex/tasks/task_e_688bcd5dce088327aecb2083d427deae