### PR TITLE
Improve feed update on post deletion

### DIFF
--- a/astrogram/src/components/PostCard/PostCard.tsx
+++ b/astrogram/src/components/PostCard/PostCard.tsx
@@ -18,6 +18,7 @@ export interface PostCardProps {
   shares?: number;
   avatarUrl: string;
   likedByMe?: boolean;
+  onDeleted?: (id: string) => void;
 }
 
 const PostCard: React.FC<PostCardProps> = ({
@@ -31,7 +32,8 @@ const PostCard: React.FC<PostCardProps> = ({
   comments = 0,
   shares = 0,
   likedByMe,
-  authorId
+  authorId,
+  onDeleted
 }) => {
 
   const { user } = useAuth();
@@ -129,7 +131,7 @@ const PostCard: React.FC<PostCardProps> = ({
       }
 
       // inform parent so it can remove this post from the UI
-      // onDeleted?.(postId);
+      onDeleted?.(id);
     } catch (err: any) {
       console.error('Delete post error:', err);
       // you could show a toast here

--- a/astrogram/src/lib/api.tsx
+++ b/astrogram/src/lib/api.tsx
@@ -40,7 +40,7 @@ export async function apiFetch(
     init.credentials = 'include';
   
     const url = `${API_BASE}${input}`;
-    let res = await fetch(url, init);
+    const res = await fetch(url, init);
   
     // 2) on 401, try to refresh once
     // if (res.status === 401) {

--- a/astrogram/src/pages/Feed.tsx
+++ b/astrogram/src/pages/Feed.tsx
@@ -152,7 +152,7 @@ const Feed: React.FC = () => {
       console.log('hello');
       // setPosts(dummyPosts);
       // setLoading(false);
-      fetchFeed<any>(1, 20)
+      fetchFeed<PostCardProps>(1, 20)
     .then(data => {
       console.log('new data!!!!!')
       console.log(data);
@@ -188,7 +188,12 @@ const Feed: React.FC = () => {
                     className=" animate-fadeIn cursor-pointer"
                     onClick={() => navigate(`/posts/${post.id}`)}
                   >
-                    <PostCard {...post} />
+                    <PostCard
+                      {...post}
+                      onDeleted={(id) =>
+                        setPosts((ps) => ps.filter((p) => p.id !== id))
+                      }
+                    />
                   </div>
                 ))}
         </div>


### PR DESCRIPTION
## Summary
- add optional `onDeleted` callback to `PostCard`
- call the callback after deleting a post
- update feed page to remove a post once deleted
- minor lint auto-fix in api helper

## Testing
- `npm test` in `backend`
- `npm run lint` *(fails: 27 problems)*

------
https://chatgpt.com/codex/tasks/task_e_688be7823a7883279204d13b85837bc0