### PR TITLE
Add Fahrenheit toggle to weather card

### DIFF
--- a/astrogram/src/App.tsx
+++ b/astrogram/src/App.tsx
@@ -21,7 +21,7 @@ import UserPage from './pages/UserPage'
 
 const App: React.FC = () => {
 
-  const { weather, loading, error } = useWeatherService();
+  const { weather, loading, error, unit, setUnit } = useWeatherService();
 
 
 
@@ -67,6 +67,8 @@ const App: React.FC = () => {
                   weather={weather}
                   loading={loading}
                   error={error}
+                  unit={unit}
+                  setUnit={setUnit}
                 />
               }
             />

--- a/astrogram/src/components/Weather/CurrentWeatherCard.tsx
+++ b/astrogram/src/components/Weather/CurrentWeatherCard.tsx
@@ -7,18 +7,32 @@ type Props = {
   icon: string;
   sunrise?: string;   // e.g. "05:56:49"
   sunset?: string;   // e.g. "20:32:27"
+  unit: 'metric' | 'us';
+  onToggle: () => void;
 };
 
-const CurrentWeatherCard: React.FC<Props> = ({ temperature, condition, icon, sunrise, sunset }) => {
+const CurrentWeatherCard: React.FC<Props> = ({ temperature, condition, icon, sunrise, sunset, unit, onToggle }) => {
 
   const fmt = (t?: string) => t ? t.slice(0, 5) : '';
 
 
   return (
     <div className="bg-neutral-800 p-6 rounded-xl text-center shadow-lg mb-6">
+      <div className="flex justify-end text-xs mb-2">
+        <label className="flex items-center gap-1 cursor-pointer">
+          <span className={unit === 'metric' ? 'text-cyan-400' : ''}>°C</span>
+          <input
+            type="checkbox"
+            checked={unit === 'us'}
+            onChange={onToggle}
+            className="form-checkbox h-3 w-3"
+          />
+          <span className={unit === 'us' ? 'text-cyan-400' : ''}>°F</span>
+        </label>
+      </div>
       <div className="text-5xl">{icon}</div>
       <div className="text-3xl font-semibold">
-        {temperature}°C
+        {temperature}°{unit === 'metric' ? 'C' : 'F'}
       </div>
       <div className="text-sm text-gray-400">{condition}</div>
 

--- a/astrogram/src/components/Weather/CurrentWeatherCard.tsx
+++ b/astrogram/src/components/Weather/CurrentWeatherCard.tsx
@@ -19,15 +19,18 @@ const CurrentWeatherCard: React.FC<Props> = ({ temperature, condition, icon, sun
   return (
     <div className="bg-neutral-800 p-6 rounded-xl text-center shadow-lg mb-6">
       <div className="flex justify-end text-xs mb-2">
-        <label className="flex items-center gap-1 cursor-pointer">
-          <span className={unit === 'metric' ? 'text-cyan-400' : ''}>°C</span>
+        <label className="inline-flex items-center gap-2 cursor-pointer select-none">
+          <span className={unit === 'metric' ? 'text-cyan-400' : 'text-gray-400'}>°C</span>
           <input
             type="checkbox"
             checked={unit === 'us'}
             onChange={onToggle}
-            className="form-checkbox h-3 w-3"
+            className="sr-only peer"
           />
-          <span className={unit === 'us' ? 'text-cyan-400' : ''}>°F</span>
+          <div
+            className="relative w-8 h-4 bg-gray-600 rounded-full peer-checked:bg-cyan-500 after:absolute after:top-0.5 after:left-0.5 after:h-3 after:w-3 after:rounded-full after:bg-white after:transition-transform peer-checked:after:translate-x-4"
+          />
+          <span className={unit === 'us' ? 'text-cyan-400' : 'text-gray-400'}>°F</span>
         </label>
       </div>
       <div className="text-5xl">{icon}</div>

--- a/astrogram/src/components/Weather/WeatherSkeleton.tsx
+++ b/astrogram/src/components/Weather/WeatherSkeleton.tsx
@@ -1,31 +1,41 @@
 const WeatherSkeleton = () => {
-    return (
-      <div className="px-4 py-6 max-w-2xl mx-auto animate-pulse space-y-6">
-        {/* Header Skeleton */}
-        <div className="h-6 bg-gray-700 rounded w-1/3"></div>
-  
-        {/* Current Weather Card Skeleton */}
-        <div className="h-32 bg-gray-800 rounded-lg"></div>
-  
-        {/* Forecast Cards Skeleton */}
-        <div className="overflow-x-auto pb-4">
-          <div className="flex gap-3 w-max">
-            {Array.from({ length: 4 }).map((_, i) => (
-              <div
-                key={i}
-                className="w-40 h-32 bg-gray-800 rounded-md flex-shrink-0"
-              ></div>
-            ))}
-          </div>
+  return (
+    <div className="px-4 py-6 max-w-2xl mx-auto space-y-6 animate-pulse">
+      {/* Header Skeleton */}
+      <div className="text-center mb-4">
+        <div className="h-6 w-2/3 mx-auto bg-gray-700 rounded mb-1" />
+        <div className="h-4 w-1/3 mx-auto bg-gray-700 rounded" />
+      </div>
+
+      {/* Current Weather Card Skeleton */}
+      <div className="bg-neutral-800 p-6 rounded-xl shadow-lg space-y-4">
+        <div className="flex justify-end">
+          <div className="h-4 w-12 bg-gray-700 rounded" />
         </div>
-  
-        {/* Moon Phase Skeleton */}
-        <div className="flex gap-2">
-          <div className="w-1/2 h-28 bg-gray-800 rounded-md"></div>
-          <div className="w-1/2 h-28 bg-gray-800 rounded-md"></div>
+        <div className="h-10 w-16 bg-gray-700 rounded-full mx-auto" />
+        <div className="h-6 w-20 bg-gray-700 rounded mx-auto" />
+        <div className="h-4 w-24 bg-gray-700 rounded mx-auto" />
+      </div>
+
+      {/* Forecast Cards Skeleton */}
+      <div className="overflow-x-auto px-0 sm:px-4 pb-4">
+        <div className="flex gap-3 w-max">
+          {Array.from({ length: 4 }).map((_, i) => (
+            <div
+              key={i}
+              className="w-40 h-52 bg-gray-800 rounded-2xl border border-gray-700 flex-shrink-0"
+            />
+          ))}
         </div>
       </div>
-    );
-  };
-  
-  export default WeatherSkeleton;
+
+      {/* Moon & Wind Skeleton */}
+      <div className="mt-6 flex gap-4">
+        <div className="w-1/2 h-44 bg-gray-800 rounded-2xl border border-gray-700" />
+        <div className="w-1/2 h-44 bg-gray-800 rounded-2xl border border-gray-700" />
+      </div>
+    </div>
+  );
+};
+
+export default WeatherSkeleton;

--- a/astrogram/src/hooks/useWeatherService.ts
+++ b/astrogram/src/hooks/useWeatherService.ts
@@ -11,6 +11,7 @@ export const useWeatherService = () => {
   const [weather, setWeather] = useState<any>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [unit, setUnit] = useState<'metric' | 'us'>('metric');
 
   useEffect(() => {
     if (!navigator.geolocation) {
@@ -20,22 +21,12 @@ export const useWeatherService = () => {
     }
 
     navigator.geolocation.getCurrentPosition(
-      async (position) => {
+      (position) => {
         const coords = {
           latitude: position.coords.latitude,
           longitude: position.coords.longitude,
         };
         setLocation(coords);
-
-        try {
-          const data = await fetchWeather(coords.latitude, coords.longitude);
-          setWeather(data);
-        } catch (err) {
-          console.error(err);
-          setError('Failed to fetch weather data.');
-        } finally {
-          setLoading(false);
-        }
       },
       (err) => {
         console.error(err);
@@ -45,10 +36,24 @@ export const useWeatherService = () => {
     );
   }, []);
 
+  useEffect(() => {
+    if (!location) return;
+    setLoading(true);
+    fetchWeather(location.latitude, location.longitude, unit)
+      .then(setWeather)
+      .catch((err) => {
+        console.error(err);
+        setError('Failed to fetch weather data.');
+      })
+      .finally(() => setLoading(false));
+  }, [location, unit]);
+
   return {
     location,
     weather,
     loading,
     error,
+    unit,
+    setUnit,
   };
 };

--- a/astrogram/src/hooks/weatherApi.ts
+++ b/astrogram/src/hooks/weatherApi.ts
@@ -1,10 +1,14 @@
 const API_BASE_URL = import.meta.env.VITE_API_BASE_URL?.trim() || '/api';
 
-export async function fetchWeather(latitude: number, longitude: number) {
+export async function fetchWeather(
+  latitude: number,
+  longitude: number,
+  unit: 'metric' | 'us' = 'metric'
+) {
   const res = await fetch(`${API_BASE_URL}/weather`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ latitude, longitude }),
+    body: JSON.stringify({ latitude, longitude, unit }),
   });
 
   if (!res.ok) throw new Error('Failed to fetch weather data');

--- a/astrogram/src/pages/WeatherPage.tsx
+++ b/astrogram/src/pages/WeatherPage.tsx
@@ -46,9 +46,11 @@ interface WeatherPageProps {
   weather: WeatherData | null;
   loading: boolean;
   error: string | null;
+  unit: 'metric' | 'us';
+  setUnit: (u: 'metric' | 'us') => void;
 }
 
-const WeatherPage: React.FC<WeatherPageProps> = ({ weather, loading, error }) => {
+const WeatherPage: React.FC<WeatherPageProps> = ({ weather, loading, error, unit, setUnit }) => {
   const today = new Date();
   const todayDateStr = today.toDateString();
   const todayStr = today.toISOString().split("T")[0];
@@ -121,6 +123,8 @@ const WeatherPage: React.FC<WeatherPageProps> = ({ weather, loading, error }) =>
         icon={icon} // You can update this dynamically later
         sunrise={sunrise}
         sunset={sunset}
+        unit={unit}
+        onToggle={() => setUnit(unit === 'metric' ? 'us' : 'metric')}
       />
 
       {/* Forecast Cards */}

--- a/backend/src/weather/weather.controller.ts
+++ b/backend/src/weather/weather.controller.ts
@@ -4,57 +4,62 @@ import { WeatherDay } from './dto/weather.types';
 
 @Controller('api/weather')
 export class WeatherController {
-
   private readonly logger = new Logger(WeatherController.name);
 
   constructor(private weatherService: WeatherService) {}
 
   @Post()
-  async getWeather(@Body() body: { latitude: number; longitude: number }) {
-    const { latitude, longitude } = body;
+  async getWeather(
+    @Body()
+    body: {
+      latitude: number;
+      longitude: number;
+      unit?: 'metric' | 'us';
+    },
+  ) {
+    const { latitude, longitude, unit = 'metric' } = body;
 
-    this.logger.log(`Received request for weather at [${latitude}, ${longitude}]`);
-
+    this.logger.log(
+      `Received request for weather at [${latitude}, ${longitude}]`,
+    );
 
     const start = Date.now();
 
-    this.logger.log('Starting parallel fetch of visibility, astronomy & location');
+    this.logger.log(
+      'Starting parallel fetch of visibility, astronomy & location',
+    );
 
     // Fetch visibility data from Open-Meteo
-       // fire all three requests at once
-       const [ visibilityData, astronomy, location ] = await Promise.all([
-        this.weatherService.fetchVisibility(latitude, longitude),
-        this.weatherService.fetchAstronomy(latitude, longitude),
-        this.weatherService.fetchLocationName(latitude, longitude),
-      ]);
+    // fire all three requests at once
+    const [visibilityData, astronomy, location] = await Promise.all([
+      this.weatherService.fetchVisibility(latitude, longitude, unit),
+      this.weatherService.fetchAstronomy(latitude, longitude, unit),
+      this.weatherService.fetchLocationName(latitude, longitude),
+    ]);
 
-      const duration = Date.now() - start;
+    const duration = Date.now() - start;
 
-
-      this.logger.log(
-        `Fetched data in ${duration}ms → ` +
+    this.logger.log(
+      `Fetched data in ${duration}ms → ` +
         `visibility days: ${visibilityData.length}, ` +
         `astronomy days: ${astronomy.length}, ` +
-        `location: ${location}`
-      );
+        `location: ${location}`,
+    );
 
-   
-    const daily: WeatherDay[] = visibilityData.map(visDay => {
+    const daily: WeatherDay[] = visibilityData.map((visDay) => {
       // find the matching astro object by date
-      const astroRaw = astronomy.find(a => a.datetime === visDay.date);
-
-
+      const astroRaw = astronomy.find((a) => a.datetime === visDay.date);
 
       return {
-        date:       visDay.date,
+        date: visDay.date,
         conditions: visDay.conditions,
         astro: astroRaw && {
           sunrise: astroRaw.sunrise,
-          sunset:  astroRaw.sunset,
+          sunset: astroRaw.sunset,
           moonrise: astroRaw.moonrise,
-          moonset:  astroRaw.moonset,
+          moonset: astroRaw.moonset,
           moonPhase: {
-            phase:        mapPhaseName(astroRaw.moonphase),
+            phase: mapPhaseName(astroRaw.moonphase),
             illumination: Math.round(astroRaw.moonphase * 100),
           },
         },
@@ -63,18 +68,18 @@ export class WeatherController {
 
     this.logger.log(`Returning payload with ${daily.length} days of data`);
 
-    return { status:'ok', coordinates:location, data:daily };
+    return { status: 'ok', coordinates: location, data: daily };
   }
 }
 
 function mapPhaseName(fraction: number): string {
-  if (fraction === 0)              return 'New Moon';
-  if (fraction > 0   && fraction < 0.25) return 'Waxing Crescent';
-  if (fraction === 0.25)           return 'First Quarter';
-  if (fraction > 0.25 && fraction < 0.5)  return 'Waxing Gibbous';
-  if (fraction === 0.5)            return 'Full Moon';
-  if (fraction > 0.5  && fraction < 0.75) return 'Waning Gibbous';
-  if (fraction === 0.75)           return 'Last Quarter';
-  if (fraction > 0.75 && fraction < 1)    return 'Waning Crescent';
+  if (fraction === 0) return 'New Moon';
+  if (fraction > 0 && fraction < 0.25) return 'Waxing Crescent';
+  if (fraction === 0.25) return 'First Quarter';
+  if (fraction > 0.25 && fraction < 0.5) return 'Waxing Gibbous';
+  if (fraction === 0.5) return 'Full Moon';
+  if (fraction > 0.5 && fraction < 0.75) return 'Waning Gibbous';
+  if (fraction === 0.75) return 'Last Quarter';
+  if (fraction > 0.75 && fraction < 1) return 'Waning Crescent';
   return 'New Moon';
 }

--- a/backend/test/app.e2e-spec.ts
+++ b/backend/test/app.e2e-spec.ts
@@ -65,7 +65,7 @@ describe('AppController (e2e)', () => {
   it('/api/weather (POST)', async () => {
     const res = await request(app.getHttpServer())
       .post('/api/weather')
-      .send({ latitude: 0, longitude: 0 })
+      .send({ latitude: 0, longitude: 0, unit: 'us' })
       .expect(201);
     expect(res.body).toEqual({
       status: 'ok',


### PR DESCRIPTION
## Summary
- allow fetching weather by metric or US units
- re-fetch weather when toggling units
- add UI toggle for °C/°F on the current weather card
- plumb unit option through backend weather endpoints
- update e2e tests

## Testing
- `npm test` in `backend`
- `npm run test:e2e` in `backend`
- `npm run lint` in `backend` *(fails: many existing lint errors)*
- `npm run lint` in `astrogram` *(fails: many existing lint errors)*


------
https://chatgpt.com/codex/tasks/task_e_688beb9207708327b3dcabcf7604830c