### PR TITLE
Fix button backgrounds being reset

### DIFF
--- a/astrogram/src/index.css
+++ b/astrogram/src/index.css
@@ -1,4 +1,11 @@
-@import "tailwindcss";
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+/* Custom brand color utilities (fallback) */
+.bg-brand { background-color: #7c3aed; }
+.bg-brand-light { background-color: #a78bfa; }
+.bg-brand-dark { background-color: #6d28d9; }
 
 
 
@@ -47,7 +54,7 @@ h1, h2, h3, h4, h5, h6 {
 button {
   cursor: pointer;
   border: none;
-  background: none;
+  /* background: none;  Removed to let Tailwind apply bg classes */
   padding: 0;
   font: inherit;
 }

--- a/astrogram/tailwind.config.cjs
+++ b/astrogram/tailwind.config.cjs
@@ -1,5 +1,5 @@
 /** @type {import('tailwindcss').Config} */
-export default {
+module.exports = {
   content: ["./index.html", "./src/**/*.{js,ts,jsx,tsx}"],
   darkMode: "class",
   theme: {
@@ -30,5 +30,9 @@ export default {
     "bg-yellow-500",
     "bg-lime-500",
     "bg-green-500",
+    "bg-brand",
+    "bg-brand-light",
+    "bg-brand-dark",
+    "hover:bg-brand-dark",
   ],
 };


### PR DESCRIPTION
## Summary
- add `tailwind.config.cjs` so the config loads correctly
- set up `@tailwind` directives in `index.css`
- add fallback `.bg-brand*` classes for purple buttons

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_688bedc0d040832789bbe61e2f2c2b9e