### PR TITLE
Fix caption on post page

### DIFF
--- a/astrogram/src/pages/PostPage.tsx
+++ b/astrogram/src/pages/PostPage.tsx
@@ -46,7 +46,8 @@ const PostPage: React.FC = () => {
           username:   data.username,
           avatarUrl:  data.avatarUrl,
           imageUrl:   data.imageUrl!,
-          caption:    data.body,
+          // API returns `caption`, not `body`
+          caption:    data.caption,
           timestamp:  data.timestamp,
           stars:      data.stars,
           comments:   data.comments,


### PR DESCRIPTION
## Summary
- fix caption not appearing on post detail page

## Testing
- `npm test` in backend
- `npm run lint` in `astrogram` *(fails: 26 errors)*

------
https://chatgpt.com/codex/tasks/task_e_688bfdae2ca0832780150cd2f759766b