### PR TITLE
Fix moonrise time handling

### DIFF
--- a/astrogram/src/components/Weather/MoonPhaseCard.tsx
+++ b/astrogram/src/components/Weather/MoonPhaseCard.tsx
@@ -5,9 +5,9 @@ import { WiMoonrise, WiMoonset } from 'react-icons/wi';
 interface MoonPhaseCardProps {
   phase: string; // e.g. "Waxing Crescent", "Full Moon", etc.
   illumination: number; // e.g. 0.62 = 62%
-  moonrise: string;         // "HH:MM:SS"
-  moonset: string;         // "HH:MM:SS"
-  className:string;
+  moonrise?: string;         // "HH:MM:SS"
+  moonset?: string;         // "HH:MM:SS"
+  className: string;
 }
 
 const phaseIcons: Record<string, string> = {
@@ -24,7 +24,7 @@ const phaseIcons: Record<string, string> = {
 const MoonPhaseCard: React.FC<MoonPhaseCardProps> = ({ phase, illumination, moonrise,
   moonset, className }) => {
   const emoji = phaseIcons[phase] ?? "🌙";
-  const fmt = (t: string) => t.slice(0, 5); // drop seconds
+  const fmt = (t?: string) => (t ? t.slice(0, 5) : '--:--'); // drop seconds safely
   const illum =  phaseToIlluminationPercent(illumination);
   console.log(illumination);
 

--- a/astrogram/src/pages/WeatherPage.tsx
+++ b/astrogram/src/pages/WeatherPage.tsx
@@ -20,8 +20,8 @@ interface WeatherConditions {
 export interface AstroData {
   sunrise: string;    // “06:12:34”
   sunset: string;    // “20:03:21”
-  moonrise: string;
-  moonset: string;
+  moonrise?: string;
+  moonset?: string;
   moonPhase: {
     phase: string;        // e.g. “Full Moon”
     illumination: number; // percent 0–100


### PR DESCRIPTION
## Summary
- make moonrise/moonset optional in weather types and card
- safely display missing moonrise/moonset times

## Testing
- `npm run lint` *(fails: many existing lint issues)*

------
https://chatgpt.com/codex/tasks/task_e_688c049565a48327b1072a33bf2f5365