### PR TITLE
Protect upload route

### DIFF
--- a/astrogram/src/components/auth/RequireProfileCompletion.tsx
+++ b/astrogram/src/components/auth/RequireProfileCompletion.tsx
@@ -23,6 +23,11 @@ export const RequireProfileCompletion: React.FC = () => {
     // else: logged in but not complete → allow
   }
 
+  // send unauthenticated users trying to upload to sign in
+  if (pathname === "/upload" && !user) {
+    return <Navigate to="/signup" replace />;
+  }
+
   // any other route, just render the child routes
   return <Outlet />;
 };


### PR DESCRIPTION
## Summary
- redirect unauthenticated users from `/upload` to sign up
- run repo linters

## Testing
- `npm run lint` in `astrogram` *(fails: 26 errors)*
- `npm run lint` in `backend`

------
https://chatgpt.com/codex/tasks/task_e_688c2888fd20832790aa9966828f3371