### PR TITLE
Fix username link to user profile

### DIFF
--- a/astrogram/src/components/PostCard/PostCard.tsx
+++ b/astrogram/src/components/PostCard/PostCard.tsx
@@ -144,7 +144,11 @@ const PostCard: React.FC<PostCardProps> = ({
 
         {/* Header */}
         <div className="px-4 sm:px-6 py-4 border-b border-gray-200 dark:border-gray-700 flex justify-between items-center">
-          <Link to={`/users/${username}/posts`} className="flex items-center gap-2 hover:underline">
+          <Link
+            to={`/users/${username}/posts`}
+            onClick={(e) => e.stopPropagation()}
+            className="flex items-center gap-2 hover:underline"
+          >
             <img
               src={avatarUrl}
               alt={`${username}'s profile`}


### PR DESCRIPTION
## Summary
- stop propagation on username link so clicking it navigates to the profile instead of post

## Testing
- `npm run lint` *(fails: many existing lint errors)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688c28bf535483279881f0c23d617913