### PR TITLE
Add margin to post button form

### DIFF
--- a/astrogram/src/components/Comments/Comments.tsx
+++ b/astrogram/src/components/Comments/Comments.tsx
@@ -70,7 +70,7 @@ const Comments: React.FC<{ postId: string }> = ({ postId }) => {
   return (
     <div className="mt-4">
       {user && (
-        <form onSubmit={handleSubmit} className="flex flex-col gap-2">
+        <form onSubmit={handleSubmit} className="flex flex-col gap-2 mb-2">
           <textarea
             value={text}
             onChange={(e) => setText(e.target.value)}


### PR DESCRIPTION
## Summary
- add bottom margin to comment form so the Post button isn't flush with the first comment

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688c290e223c8327b7aed00e107e2b64