### PR TITLE
Add dewpoint to weather service

### DIFF
--- a/astrogram/src/data/mockWeather.ts
+++ b/astrogram/src/data/mockWeather.ts
@@ -41,6 +41,7 @@ export const conditionColors = {
       seeing?: Partial<Record<TimeBlock, number>>;        // custom astronomy score
       transparency?: Partial<Record<TimeBlock, number>>;  // custom transparency score
       temperature?: Partial<Record<TimeBlock, number>>;
+      dewpoint?: Partial<Record<TimeBlock, number>>;
       visibility?: Partial<Record<TimeBlock, number>>;
       cloudcover?: Partial<Record<TimeBlock, number>>;
       humidity?: Partial<Record<TimeBlock, number>>;

--- a/astrogram/src/pages/WeatherPage.tsx
+++ b/astrogram/src/pages/WeatherPage.tsx
@@ -8,6 +8,7 @@ import WindCard from "../components/Weather/WindCard";
 
 interface WeatherConditions {
   temperature?: Record<string, number>;
+  dewpoint?: Record<string, number>;
   visibility?: Record<string, number>;
   cloudcover?: Record<string, number>;
   humidity?: Record<string, number>;

--- a/backend/src/weather/dto/weather.types.ts
+++ b/backend/src/weather/dto/weather.types.ts
@@ -4,6 +4,7 @@ export type TimeBlock = "0" | "6" | "12" | "18" | "21";
 
 export const timeBlockDataKeys = {
   temperature: "temperature_2m",
+  dewpoint: "dewpoint_2m",
   visibility: "visibility",
   cloudcover: "cloudcover",
   humidity: "relative_humidity_2m",
@@ -13,6 +14,7 @@ export const timeBlockDataKeys = {
 
 interface WeatherConditions {
     temperature?: Record<string, number>;
+    dewpoint?: Record<string, number>;
     visibility?: Record<string, number>;
     cloudcover?: Record<string, number>;
     humidity?: Record<string, number>;

--- a/backend/src/weather/weather.service.ts
+++ b/backend/src/weather/weather.service.ts
@@ -49,6 +49,7 @@ export class WeatherService {
             windspeed_unit: unit === 'us' ? 'mph' : 'kmh',
             hourly: [
               'temperature_2m',
+              'dewpoint_2m',
               'visibility',
               'cloudcover',
               'relative_humidity_2m',
@@ -79,6 +80,7 @@ export class WeatherService {
             date: dateKey,
             conditions: {
               temperature: {},
+              dewpoint: {},
               visibility: {},
               cloudcover: {},
               humidity: {},
@@ -92,6 +94,8 @@ export class WeatherService {
 
         resultMap[dateKey].conditions.temperature[hr] =
           hourly.temperature_2m[i];
+        resultMap[dateKey].conditions.dewpoint[hr] =
+          hourly.dewpoint_2m[i];
         resultMap[dateKey].conditions.visibility[hr] = hourly.visibility[i];
         resultMap[dateKey].conditions.cloudcover[hr] = hourly.cloudcover[i];
         resultMap[dateKey].conditions.humidity[hr] =


### PR DESCRIPTION
## Summary
- request dew point data from Open-Meteo
- expose dew point in backend and frontend weather types

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688cef16080c83278b9ca78761b025ff