### PR TITLE
Fix comment preview user info

### DIFF
--- a/backend/src/comments/comments.service.ts
+++ b/backend/src/comments/comments.service.ts
@@ -19,6 +19,7 @@ export class CommentsService {
 
     const comment = await this.prisma.comment.create({
       data: { text: dto.text, authorId: userId, postId },
+      include: { author: { select: { username: true, avatarUrl: true } } },
     });
 
     const post = await this.prisma.post.findUnique({ where: { id: postId }, select: { authorId: true } });
@@ -26,7 +27,16 @@ export class CommentsService {
       await this.notifications.create(post.authorId, userId, NotificationType.COMMENT, postId, comment.id);
     }
 
-    return comment;
+    return {
+      id: comment.id,
+      text: comment.text,
+      authorId: comment.authorId,
+      username: comment.author.username!,
+      avatarUrl: comment.author.avatarUrl ?? '',
+      timestamp: comment.createdAt.toISOString(),
+      likes: comment.likes,
+      likedByMe: false,
+    };
   }
 
   async getCommentsForPost(postId: string, currentUserId?: string) {


### PR DESCRIPTION
## Summary
- include author info when creating a comment so new comments display username and avatar immediately

## Testing
- `npm test` in `backend`

------
https://chatgpt.com/codex/tasks/task_e_688cfa07bf5c8327b807d071c62095d8