### PR TITLE
Add lounge subtabs

### DIFF
--- a/astrogram/src/components/Navbar/Navbar.tsx
+++ b/astrogram/src/components/Navbar/Navbar.tsx
@@ -134,7 +134,41 @@ const Navbar = () => {
             </button>
             {loungesOpen && (
               <ul className="pl-4 text-sm space-y-1">
-                <li><Link to="/lounge" onClick={() => setSideMenuOpen(false)}>Astro Lounge</Link></li>
+                <li>
+                  <Link to="/lounge" onClick={() => setSideMenuOpen(false)}>
+                    Astro Lounge
+                  </Link>
+                </li>
+                <li>
+                  <Link to="/lounge/lunisolar" onClick={() => setSideMenuOpen(false)}>
+                    LuniSolar
+                  </Link>
+                </li>
+                <li>
+                  <Link to="/lounge/planetary" onClick={() => setSideMenuOpen(false)}>
+                    Planetary
+                  </Link>
+                </li>
+                <li>
+                  <Link to="/lounge/dso" onClick={() => setSideMenuOpen(false)}>
+                    DSO
+                  </Link>
+                </li>
+                <li>
+                  <Link to="/lounge/equipmet" onClick={() => setSideMenuOpen(false)}>
+                    Equipmet
+                  </Link>
+                </li>
+                <li>
+                  <Link to="/lounge/astroadjacent" onClick={() => setSideMenuOpen(false)}>
+                    AstroAdjacent
+                  </Link>
+                </li>
+                <li>
+                  <Link to="/lounge/askastro" onClick={() => setSideMenuOpen(false)}>
+                    AskAstro
+                  </Link>
+                </li>
               </ul>
             )}
             <h3 className="mt-4 mb-1 text-lg font-semibold">Settings</h3>


### PR DESCRIPTION
## Summary
- expand the Lounges menu in the hamburger navigation

## Testing
- `npm run lint` in `astrogram`
- `npm run lint` in `backend`
- `npm test` in `backend`


------
https://chatgpt.com/codex/tasks/task_e_688d0876f9488327b26e13d05719b7d1