### PR TITLE
Apply 314 char limit to posts and comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 ColliMate is a full-stack social app for sharing and discovering cosmic photography and musings. Users can sign up via Google or Facebook, complete their profile, post images with captions, interact (like, share, repost), and browse a weighted feed.
 
+Posts and comments are limited to **314** characters each.
+
 ---
 
 ## 🚀 Tech Stack

--- a/backend/src/comments/comments.service.ts
+++ b/backend/src/comments/comments.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, Logger, ForbiddenException } from '@nestjs/common';
+import { Injectable, Logger, ForbiddenException, BadRequestException } from '@nestjs/common';
 
 import { PrismaService } from '../prisma/prisma.service';
 import { CreateCommentDto } from './dto/create-comment.dto';
@@ -16,6 +16,10 @@ export class CommentsService {
 
   async createComment(userId: string, postId: string, dto: CreateCommentDto) {
     this.logger.log(`User ${userId} creating comment on post ${postId}`);
+
+    if (dto.text && dto.text.length > 314) {
+      throw new BadRequestException('Comment text must be 314 characters or fewer');
+    }
 
     const comment = await this.prisma.comment.create({
       data: { text: dto.text, authorId: userId, postId },

--- a/backend/src/posts/post.service.ts
+++ b/backend/src/posts/post.service.ts
@@ -5,7 +5,8 @@ import {
     InternalServerErrorException,
     Logger,
     NotFoundException,
-    ForbiddenException
+    ForbiddenException,
+    BadRequestException,
 } from '@nestjs/common'
 import { PrismaService } from '../prisma/prisma.service'
 import { InteractionType, Post, NotificationType } from '@prisma/client'
@@ -54,6 +55,10 @@ export class PostsService {
         file?: Express.Multer.File,
     ): Promise<Post> {
         this.logger.log(`Creating post for user ${userId}: "${dto.title}"`)
+
+        if (dto.body && dto.body.length > 314) {
+            throw new BadRequestException('Post body must be 314 characters or fewer')
+        }
 
         // 1) if they sent a file, upload it and grab the public URL
         let imageUrl: string | undefined


### PR DESCRIPTION
## Summary
- limit post and comment length to 314 characters
- mention the limit in the README

## Testing
- `npm test` *(backend)*
- `npm run lint` *(fails: 153 problems)*

------
https://chatgpt.com/codex/tasks/task_e_688d05a5bf5c8327bc4dbdbb32808134