### PR TITLE
Allow posts without image attachments

### DIFF
--- a/astrogram/src/components/PostCard/PostCard.tsx
+++ b/astrogram/src/components/PostCard/PostCard.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState, useRef } from "react";
 import { useNavigate, Link } from 'react-router-dom';
 import { formatDistanceToNow } from "date-fns";
 import { Star, MessageCircle, Share2, Repeat2, Bookmark, MoreVertical } from "lucide-react";
-import { likePost, sharePost, repostPost, apiFetch } from '../../lib/api';
+import { sharePost, repostPost, apiFetch } from '../../lib/api';
 import { useAuth } from "../../contexts/AuthContext";
 
 
@@ -10,7 +10,7 @@ export interface PostCardProps {
   id: string
   authorId: string
   username: string;
-  imageUrl: string;
+  imageUrl?: string;
   caption: string;
   timestamp: string;
   stars?: number;
@@ -94,14 +94,14 @@ const PostCard: React.FC<PostCardProps> = ({
 
   const handleRepost = async () => {
     if (reposted) return;
-    try {
-      const { count } = await repostPost(id);
-      setShareCount(prev => prev); // leave shareCount alone
-      setReposted(true);
-      // if you want to show repost count separately, add another state
-    } catch (err) {
-      console.error("Failed to repost:", err);
-    }
+      try {
+        await repostPost(id);
+        setShareCount(prev => prev); // leave shareCount alone
+        setReposted(true);
+        // if you want to show repost count separately, add another state
+      } catch (err: unknown) {
+        console.error("Failed to repost:", err);
+      }
   };
 
   // close menu on outside click
@@ -132,7 +132,7 @@ const PostCard: React.FC<PostCardProps> = ({
 
       // inform parent so it can remove this post from the UI
       onDeleted?.(id);
-    } catch (err: any) {
+    } catch (err: unknown) {
       console.error('Delete post error:', err);
       // you could show a toast here
     }
@@ -188,17 +188,19 @@ const PostCard: React.FC<PostCardProps> = ({
         </div>
 
         {/* Image */}
-        <div className="w-full aspect-video overflow-hidden">
-          <img
-            src={imageUrl}
-            alt={`Post by ${username}: ${caption}`}
-            className="object-cover w-full h-full"
-            loading="lazy"
-            onError={(e) => {
-              (e.currentTarget as HTMLImageElement).src = "/fallback.jpg.png";
-            }}
-          />
-        </div>
+        {imageUrl && (
+          <div className="w-full aspect-video overflow-hidden">
+            <img
+              src={imageUrl}
+              alt={`Post by ${username}: ${caption}`}
+              className="object-cover w-full h-full"
+              loading="lazy"
+              onError={(e) => {
+                (e.currentTarget as HTMLImageElement).src = "/fallback.jpg.png";
+              }}
+            />
+          </div>
+        )}
 
         {/* Caption */}
         <div className="px-4 sm:px-6 py-4 text-sm">{caption}</div>

--- a/astrogram/src/components/UploadForm/UploadForm.tsx
+++ b/astrogram/src/components/UploadForm/UploadForm.tsx
@@ -37,17 +37,13 @@ const UploadForm: React.FC = () => {
 
   const handleSubmit = async (e: FormEvent) => {
     e.preventDefault()
-    if (!file) {
-      setError('Please select an image.')
-      return
-    }
     setError(null)
     setLoading(true)
 
     try {
       const form = new FormData()
       form.append('body', caption)
-      form.append('image', file)
+      if (file) form.append('image', file)
 
       const res = await apiFetch('/posts', {
         method: 'POST',
@@ -69,8 +65,9 @@ const UploadForm: React.FC = () => {
       setCaption('')
       setFile(null)
       setPreview(null)
-    } catch (err: any) {
-      setError(err.message || 'Something went wrong')
+      } catch (err: unknown) {
+        const message = err instanceof Error ? err.message : 'Something went wrong'
+        setError(message)
     } finally {
       setLoading(false)
     }

--- a/astrogram/src/pages/PostPage.tsx
+++ b/astrogram/src/pages/PostPage.tsx
@@ -8,10 +8,7 @@ import Comments                         from '../components/Comments/Comments'
 import CommentsSkeleton                 from '../components/Comments/CommentsSkeleton'
 import { apiFetch }                     from '../lib/api'
 
-interface FullPost extends PostCardProps {
-  // you can extend with other fields like comments array if you have them
-//   commentsCount: number
-}
+type FullPost = PostCardProps
 
 const PostPage: React.FC = () => {
   const { id }     = useParams<{ id: string }>()
@@ -45,7 +42,7 @@ const PostPage: React.FC = () => {
           id:         data.id,
           username:   data.username,
           avatarUrl:  data.avatarUrl,
-          imageUrl:   data.imageUrl!,
+          imageUrl:   data.imageUrl,
           // API returns `caption`, not `body`
           caption:    data.caption,
           timestamp:  data.timestamp,


### PR DESCRIPTION
## Summary
- let users submit posts with just text
- hide the image block on posts when no image URL is provided

## Testing
- `npm test` (frontend: missing script)
- `npx eslint src/components/UploadForm/UploadForm.tsx src/components/PostCard/PostCard.tsx src/pages/PostPage.tsx`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6890eb0aec648327b926c7957f7d5f15