### PR TITLE
Show lounge post titles and add detail view

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ColliMate is a full-stack social app for sharing and discovering cosmic photography and musings. Users can sign up via Google or Facebook, complete their profile, post images with captions, interact (like, share, repost), and browse a weighted feed.
 
-Posts and comments are limited to **314** characters each.
+Posts are limited to **314** characters, while comments have no character limit.
 
 ---
 

--- a/astrogram/src/App.tsx
+++ b/astrogram/src/App.tsx
@@ -17,6 +17,7 @@ import UserPage from './pages/UserPage'
 import LoungePage from './pages/LoungePage'
 import LoungesPage from './pages/LoungesPage'
 import LoungePostPage from './pages/LoungePostPage'
+import LoungePostDetailPage from './pages/LoungePostDetailPage'
 
 
 
@@ -53,6 +54,7 @@ const App: React.FC = () => {
           <Route path="/users/:username/:tab" element={<UserPage />} />
           <Route path="/lounge" element={<LoungesPage />} />
           <Route path="/lounge/:loungeName" element={<LoungePage />} />
+          <Route path="/lounge/:loungeName/posts/:postId" element={<LoungePostDetailPage />} />
           <Route element={<RequireProfileCompletion />}>
             <Route path="/lounge/:loungeName/post" element={<LoungePostPage />} />
             <Route path="/upload" element={<UploadForm />} />

--- a/astrogram/src/components/BottomNavbar/BottomNavbar.tsx
+++ b/astrogram/src/components/BottomNavbar/BottomNavbar.tsx
@@ -25,6 +25,12 @@ const BottomNavbar: React.FC = () => {
   const [activeIndex, setActiveIndex] = useState(0);
 
   useEffect(() => {
+    if (location.pathname.includes("lounge")) {
+      const loungeIdx = tabs.findIndex(tab => tab.name === "Lounges");
+      if (loungeIdx !== -1) setActiveIndex(loungeIdx);
+      return;
+    }
+
     const idx = tabs.findIndex(tab => tab.path === location.pathname);
     if (idx !== -1) setActiveIndex(idx);
   }, [location.pathname]);

--- a/astrogram/src/components/PostCard/PostCard.tsx
+++ b/astrogram/src/components/PostCard/PostCard.tsx
@@ -10,6 +10,7 @@ export interface PostCardProps {
   id: string
   authorId: string
   username: string;
+  title?: string;
   imageUrl?: string;
   caption: string;
   timestamp: string;

--- a/astrogram/src/components/auth/RequireProfileCompletion.tsx
+++ b/astrogram/src/components/auth/RequireProfileCompletion.tsx
@@ -28,6 +28,11 @@ export const RequireProfileCompletion: React.FC = () => {
     return <Navigate to="/signup" replace />;
   }
 
+  // redirect unauthenticated users away from lounge post creation
+  if (/^\/lounge\/[^/]+\/post$/.test(pathname) && !user) {
+    return <Navigate to="/signup" replace />;
+  }
+
   // any other route, just render the child routes
   return <Outlet />;
 };

--- a/astrogram/src/contexts/AuthContext.tsx
+++ b/astrogram/src/contexts/AuthContext.tsx
@@ -113,6 +113,21 @@ export const AuthProvider: React.FC<{ children: ReactNode }> = ({ children }) =>
 
 export function useAuth() {
   const ctx = useContext(AuthContext);
-  if (!ctx) throw new Error("useAuth must be inside AuthProvider");
+  if (!ctx) {
+    return {
+      user: null,
+      loading: false,
+      // provide stubs that warn when used without provider
+      login: async () => {
+        throw new Error('AuthProvider is missing');
+      },
+      logout: () => {
+        throw new Error('AuthProvider is missing');
+      },
+      updateFollowedLounge: async () => {
+        throw new Error('AuthProvider is missing');
+      },
+    };
+  }
   return ctx;
 }

--- a/astrogram/src/contexts/AuthContext.tsx
+++ b/astrogram/src/contexts/AuthContext.tsx
@@ -23,6 +23,7 @@ interface AuthContextType {
   loading: boolean;
   login: (accessToken: string) => Promise<User>;
   logout: () => void;
+  updateFollowedLounge: (loungeId: string, follow: boolean) => void;
 }
 
 const AuthContext = createContext<AuthContextType | undefined>(undefined);
@@ -78,8 +79,19 @@ export const AuthProvider: React.FC<{ children: ReactNode }> = ({ children }) =>
     // optionally call your backend /logout endpoint to clear the refresh cookie
   };
 
+  const updateFollowedLounge = (loungeId: string, follow: boolean) => {
+    setUser((prev) => {
+      if (!prev) return prev;
+      const current = prev.followedLounges ?? [];
+      const followedLounges = follow
+        ? [...current, loungeId]
+        : current.filter((id) => id !== loungeId);
+      return { ...prev, followedLounges };
+    });
+  };
+
   return (
-    <AuthContext.Provider value={{ user, loading, login, logout }}>
+    <AuthContext.Provider value={{ user, loading, login, logout, updateFollowedLounge }}>
       {children}
     </AuthContext.Provider>
   );

--- a/astrogram/src/pages/LoungePage.tsx
+++ b/astrogram/src/pages/LoungePage.tsx
@@ -1,9 +1,11 @@
 import { Link, useParams, useNavigate } from "react-router-dom";
 import { useEffect, useState } from "react";
 import { fetchLoungePosts, fetchLounge } from "../lib/api";
-import PostCard from "../components/PostCard/PostCard";
-import PostSkeleton from "../components/PostCard/PostSkeleton";
-import type { PostCardProps } from "../components/PostCard/PostCard";
+
+interface LoungePostSummary {
+  id: string;
+  title: string;
+}
 
 interface LoungeInfo {
   id: string;
@@ -17,7 +19,7 @@ const LoungePage: React.FC = () => {
   const [lounge, setLounge] = useState<LoungeInfo | null>(null);
   const [loadingLounge, setLoadingLounge] = useState(true);
   const [loadingPosts, setLoadingPosts] = useState(true);
-  const [posts, setPosts] = useState<PostCardProps[]>([]);
+  const [posts, setPosts] = useState<LoungePostSummary[]>([]);
   const navigate = useNavigate();
 
   useEffect(() => {
@@ -30,7 +32,7 @@ const LoungePage: React.FC = () => {
 
   useEffect(() => {
     if (!loungeName) return;
-    fetchLoungePosts<PostCardProps>(loungeName, 1, 20)
+    fetchLoungePosts<LoungePostSummary>(loungeName, 1, 20)
       .then((data) => {
         setPosts(data.posts);
         setLoadingPosts(false);
@@ -71,17 +73,23 @@ const LoungePage: React.FC = () => {
         </Link>
       </div>
       <div className="w-full max-w-3xl mx-auto space-y-4">
-        {loadingPosts
-          ? Array.from({ length: 4 }).map((_, i) => <PostSkeleton key={i} />)
-          : posts.map((post) => (
-              <div
-                key={post.id}
-                className="animate-fadeIn cursor-pointer"
-                onClick={() => navigate(`/posts/${post.id}`)}
-              >
-                <PostCard {...post} />
-              </div>
-            ))}
+        {loadingPosts ? (
+          <div>Loading posts...</div>
+        ) : (
+          posts.map((post) => (
+            <div
+              key={post.id}
+              className="p-4 bg-white dark:bg-gray-800 rounded cursor-pointer hover:bg-gray-100 dark:hover:bg-gray-700"
+              onClick={() =>
+                navigate(
+                  `/lounge/${encodeURIComponent(lounge.name)}/posts/${post.id}`,
+                )
+              }
+            >
+              <h2 className="text-lg font-semibold">{post.title}</h2>
+            </div>
+          ))
+        )}
       </div>
     </div>
   );

--- a/astrogram/src/pages/LoungePage.tsx
+++ b/astrogram/src/pages/LoungePage.tsx
@@ -2,6 +2,7 @@ import { Link, useParams, useNavigate } from "react-router-dom";
 import { useEffect, useState } from "react";
 import { formatDistanceToNow } from "date-fns";
 import { fetchLoungePosts, fetchLounge } from "../lib/api";
+import { useAuth } from "../contexts/AuthContext";
 
 interface LoungePostSummary {
   id: string;
@@ -21,6 +22,7 @@ interface LoungeInfo {
 
 const LoungePage: React.FC = () => {
   const { loungeName } = useParams<{ loungeName: string }>();
+  const { user } = useAuth();
   const [lounge, setLounge] = useState<LoungeInfo | null>(null);
   const [loadingLounge, setLoadingLounge] = useState(true);
   const [loadingPosts, setLoadingPosts] = useState(true);
@@ -70,12 +72,14 @@ const LoungePage: React.FC = () => {
       </div>
       <div className="flex items-center justify-between mb-6">
         <h1 className="text-2xl font-bold">{lounge.name}</h1>
-        <Link
-          to={`/lounge/${encodeURIComponent(lounge.name)}/post`}
-          className="px-4 py-2 rounded bg-purple-600 text-white hover:bg-purple-700 transition-colors"
-        >
-          Post
-        </Link>
+        {user && (
+          <Link
+            to={`/lounge/${encodeURIComponent(lounge.name)}/post`}
+            className="px-4 py-2 rounded bg-purple-600 text-white hover:bg-purple-700 transition-colors"
+          >
+            Post
+          </Link>
+        )}
       </div>
       <div className="w-full max-w-3xl mx-auto space-y-4">
         {loadingPosts ? (

--- a/astrogram/src/pages/LoungePage.tsx
+++ b/astrogram/src/pages/LoungePage.tsx
@@ -1,10 +1,15 @@
 import { Link, useParams, useNavigate } from "react-router-dom";
 import { useEffect, useState } from "react";
+import { formatDistanceToNow } from "date-fns";
 import { fetchLoungePosts, fetchLounge } from "../lib/api";
 
 interface LoungePostSummary {
   id: string;
   title: string;
+  username: string;
+  avatarUrl: string;
+  timestamp: string;
+  comments: number;
 }
 
 interface LoungeInfo {
@@ -86,6 +91,20 @@ const LoungePage: React.FC = () => {
                 )
               }
             >
+              <div className="flex items-center mb-1">
+                <img
+                  src={post.avatarUrl}
+                  alt={`${post.username} avatar`}
+                  className="w-8 h-8 rounded-full object-cover mr-2"
+                />
+                <span className="font-medium">{post.username}</span>
+                <span className="ml-2 text-sm text-gray-500">
+                  {formatDistanceToNow(new Date(post.timestamp), { addSuffix: true })}
+                </span>
+                <span className="ml-auto text-sm text-gray-500">
+                  {post.comments} replies
+                </span>
+              </div>
               <h2 className="text-lg font-semibold">{post.title}</h2>
             </div>
           ))

--- a/astrogram/src/pages/LoungePostDetailPage.tsx
+++ b/astrogram/src/pages/LoungePostDetailPage.tsx
@@ -1,11 +1,15 @@
 import React, { useEffect, useState } from "react";
 import { useParams } from "react-router-dom";
+import { formatDistanceToNow } from "date-fns";
 import { apiFetch } from "../lib/api";
 
 interface Post {
   id: string;
   title: string;
   caption: string;
+  username: string;
+  avatarUrl: string;
+  timestamp: string;
 }
 
 const LoungePostDetailPage: React.FC = () => {
@@ -29,7 +33,20 @@ const LoungePostDetailPage: React.FC = () => {
 
   return (
     <div className="py-6">
-      <h1 className="text-2xl font-bold mb-4">{post.title}</h1>
+      <div className="flex items-center mb-4">
+        <img
+          src={post.avatarUrl}
+          alt={`${post.username} avatar`}
+          className="w-10 h-10 rounded-full object-cover mr-3"
+        />
+        <div>
+          <div className="font-medium">{post.username}</div>
+          <div className="text-sm text-gray-500">
+            {formatDistanceToNow(new Date(post.timestamp), { addSuffix: true })}
+          </div>
+        </div>
+      </div>
+      <h1 className="text-2xl font-bold mb-2">{post.title}</h1>
       <p>{post.caption}</p>
     </div>
   );

--- a/astrogram/src/pages/LoungePostDetailPage.tsx
+++ b/astrogram/src/pages/LoungePostDetailPage.tsx
@@ -48,7 +48,7 @@ const LoungePostDetailPage: React.FC = () => {
         </div>
       </div>
       <h1 className="text-2xl font-bold mb-2">{post.title}</h1>
-      <p>{post.caption}</p>
+      <div dangerouslySetInnerHTML={{ __html: post.caption }} />
       <hr className="my-4 border-t border-white/20" />
       <Comments postId={post.id} />
     </div>

--- a/astrogram/src/pages/LoungePostDetailPage.tsx
+++ b/astrogram/src/pages/LoungePostDetailPage.tsx
@@ -1,0 +1,38 @@
+import React, { useEffect, useState } from "react";
+import { useParams } from "react-router-dom";
+import { apiFetch } from "../lib/api";
+
+interface Post {
+  id: string;
+  title: string;
+  caption: string;
+}
+
+const LoungePostDetailPage: React.FC = () => {
+  const { postId } = useParams<{ postId: string }>();
+  const [post, setPost] = useState<Post | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!postId) return;
+    apiFetch(`/posts/${postId}`)
+      .then(res => res.json())
+      .then(data => setPost(data))
+      .catch(() => setError("Could not load post."))
+      .finally(() => setLoading(false));
+  }, [postId]);
+
+  if (loading) return <div className="py-6">Loading...</div>;
+  if (error) return <div className="py-6">{error}</div>;
+  if (!post) return <div className="py-6">Post not found.</div>;
+
+  return (
+    <div className="py-6">
+      <h1 className="text-2xl font-bold mb-4">{post.title}</h1>
+      <p>{post.caption}</p>
+    </div>
+  );
+};
+
+export default LoungePostDetailPage;

--- a/astrogram/src/pages/LoungePostDetailPage.tsx
+++ b/astrogram/src/pages/LoungePostDetailPage.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from "react";
 import { useParams } from "react-router-dom";
 import { formatDistanceToNow } from "date-fns";
 import { apiFetch } from "../lib/api";
+import Comments from "../components/Comments/Comments";
 
 interface Post {
   id: string;
@@ -48,6 +49,8 @@ const LoungePostDetailPage: React.FC = () => {
       </div>
       <h1 className="text-2xl font-bold mb-2">{post.title}</h1>
       <p>{post.caption}</p>
+      <hr className="my-4 border-t border-white/20" />
+      <Comments postId={post.id} />
     </div>
   );
 };

--- a/astrogram/src/pages/LoungePostPage.tsx
+++ b/astrogram/src/pages/LoungePostPage.tsx
@@ -54,6 +54,10 @@ const LoungePostPage: React.FC = () => {
   const handleSubmit = async (e: FormEvent) => {
     e.preventDefault();
     setError(null);
+    if (!title.trim() || !body.trim()) {
+      setError("Title and body are required");
+      return;
+    }
     setLoading(true);
 
     try {
@@ -88,20 +92,22 @@ const LoungePostPage: React.FC = () => {
           <label className="block text-sm mb-1">Title</label>
           <input
             type="text"
-            value={title}
-            onChange={(e) => setTitle(e.target.value)}
-            className="w-full px-3 py-2 rounded bg-gray-800"
-          />
-        </div>
-        <div>
-          <label className="block text-sm mb-1">Body</label>
-          <textarea
-            rows={4}
-            value={body}
-            onChange={(e) => setBody(e.target.value)}
-            className="w-full px-3 py-2 rounded bg-gray-800"
-          />
-        </div>
+          value={title}
+          onChange={(e) => setTitle(e.target.value)}
+          required
+          className="w-full px-3 py-2 rounded bg-gray-800"
+        />
+      </div>
+      <div>
+        <label className="block text-sm mb-1">Body</label>
+        <textarea
+          rows={4}
+          value={body}
+          onChange={(e) => setBody(e.target.value)}
+          required
+          className="w-full px-3 py-2 rounded bg-gray-800"
+        />
+      </div>
         <div>
           <label
             htmlFor="post-images"

--- a/astrogram/src/pages/LoungePostPage.tsx
+++ b/astrogram/src/pages/LoungePostPage.tsx
@@ -5,6 +5,7 @@ import React, {
   useEffect,
 } from "react";
 import { useNavigate, useParams } from "react-router-dom";
+import { useAuth } from "../contexts/AuthContext";
 import { apiFetch } from "../lib/api";
 import { UploadCloud } from "lucide-react";
 
@@ -13,6 +14,7 @@ const MAX_IMAGES = 4;
 const LoungePostPage: React.FC = () => {
   const { loungeName } = useParams<{ loungeName: string }>();
   const navigate = useNavigate();
+  const { user, loading: authLoading } = useAuth();
 
   const [title, setTitle] = useState("");
   const [body, setBody] = useState("");
@@ -20,6 +22,12 @@ const LoungePostPage: React.FC = () => {
   const [previews, setPreviews] = useState<string[]>([]);
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    if (!authLoading && !user) {
+      navigate('/signup', { replace: true });
+    }
+  }, [authLoading, user, navigate]);
 
   useEffect(() => {
     const urls = files.map((f) => URL.createObjectURL(f));

--- a/astrogram/src/pages/LoungePostPage.tsx
+++ b/astrogram/src/pages/LoungePostPage.tsx
@@ -3,6 +3,7 @@ import React, {
   type ChangeEvent,
   type FormEvent,
   useEffect,
+  useRef,
 } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 import { useAuth } from "../contexts/AuthContext";
@@ -18,6 +19,7 @@ const LoungePostPage: React.FC = () => {
 
   const [title, setTitle] = useState("");
   const [body, setBody] = useState("");
+  const editorRef = useRef<HTMLDivElement>(null);
   const [files, setFiles] = useState<File[]>([]);
   const [previews, setPreviews] = useState<string[]>([]);
   const [error, setError] = useState<string | null>(null);
@@ -54,7 +56,8 @@ const LoungePostPage: React.FC = () => {
   const handleSubmit = async (e: FormEvent) => {
     e.preventDefault();
     setError(null);
-    if (!title.trim() || !body.trim()) {
+    const plain = body.replace(/<[^>]*>/g, "").trim();
+    if (!title.trim() || !plain) {
       setError("Title and body are required");
       return;
     }
@@ -100,12 +103,53 @@ const LoungePostPage: React.FC = () => {
       </div>
       <div>
         <label className="block text-sm mb-1">Body</label>
-        <textarea
-          rows={4}
-          value={body}
-          onChange={(e) => setBody(e.target.value)}
-          required
-          className="w-full px-3 py-2 rounded bg-gray-800"
+        <div className="flex gap-2 mb-2">
+          <button
+            type="button"
+            onClick={() => {
+              document.execCommand("bold");
+              editorRef.current?.focus();
+            }}
+            className="px-2 py-1 rounded bg-gray-700"
+          >
+            B
+          </button>
+          <button
+            type="button"
+            onClick={() => {
+              document.execCommand("italic");
+              editorRef.current?.focus();
+            }}
+            className="px-2 py-1 rounded bg-gray-700 italic"
+          >
+            I
+          </button>
+          <button
+            type="button"
+            onClick={() => {
+              document.execCommand("insertUnorderedList");
+              editorRef.current?.focus();
+            }}
+            className="px-2 py-1 rounded bg-gray-700"
+          >
+            •
+          </button>
+          <button
+            type="button"
+            onClick={() => {
+              document.execCommand("insertOrderedList");
+              editorRef.current?.focus();
+            }}
+            className="px-2 py-1 rounded bg-gray-700"
+          >
+            1.
+          </button>
+        </div>
+        <div
+          ref={editorRef}
+          contentEditable
+          className="w-full px-3 py-2 rounded bg-gray-800 min-h-[6rem]"
+          onInput={() => setBody(editorRef.current?.innerHTML || "")}
         />
       </div>
         <div>

--- a/astrogram/src/pages/LoungesPage.tsx
+++ b/astrogram/src/pages/LoungesPage.tsx
@@ -14,7 +14,7 @@ interface LoungeInfo {
 }
 
 const LoungesPage: React.FC = () => {
-  const { user } = useAuth();
+  const { user, updateFollowedLounge } = useAuth();
   const [sortBy, setSortBy] = useState<"name" | "lastPost">("name");
   const [followed, setFollowed] = useState<Record<string, boolean>>({});
 
@@ -97,12 +97,14 @@ const LoungesPage: React.FC = () => {
                         e.preventDefault();
                         e.stopPropagation();
                         try {
-                          if (followed[lounge.id]) await unfollowLounge(lounge.name);
+                          const isFollowed = !!followed[lounge.id];
+                          if (isFollowed) await unfollowLounge(lounge.name);
                           else await followLounge(lounge.name);
                           setFollowed((prev) => ({
                             ...prev,
                             [lounge.id]: !prev[lounge.id],
                           }));
+                          updateFollowedLounge(lounge.id, !isFollowed);
                         } catch {}
                       }}
                       className="px-2 py-1 bg-neutral-700 rounded text-xs text-neutral-200"

--- a/astrogram/src/pages/PostPage.tsx
+++ b/astrogram/src/pages/PostPage.tsx
@@ -41,6 +41,7 @@ const PostPage: React.FC = () => {
         const p: FullPost = {
           id:         data.id,
           username:   data.username,
+          ...(data.title ? { title: data.title } : {}),
           avatarUrl:  data.avatarUrl,
           imageUrl:   data.imageUrl,
           // API returns `caption`, not `body`

--- a/backend/src/comments/comments.service.ts
+++ b/backend/src/comments/comments.service.ts
@@ -17,9 +17,6 @@ export class CommentsService {
   async createComment(userId: string, postId: string, dto: CreateCommentDto) {
     this.logger.log(`User ${userId} creating comment on post ${postId}`);
 
-    if (dto.text && dto.text.length > 314) {
-      throw new BadRequestException('Comment text must be 314 characters or fewer');
-    }
     let parentAuthorId: string | null = null;
     if (dto.parentId) {
       const parent = await this.prisma.comment.findUnique({

--- a/backend/src/posts/post.service.ts
+++ b/backend/src/posts/post.service.ts
@@ -56,6 +56,10 @@ export class PostsService {
     ): Promise<Post> {
         this.logger.log(`Creating post for user ${userId}: "${dto.title}"`)
 
+        if (dto.loungeId && (!dto.title?.trim() || !dto.body?.trim())) {
+            throw new BadRequestException('Title and body are required for lounge posts')
+        }
+
         if (!dto.loungeId && dto.body && dto.body.length > 314) {
             throw new BadRequestException('Post body must be 314 characters or fewer')
         }

--- a/backend/src/posts/post.service.ts
+++ b/backend/src/posts/post.service.ts
@@ -217,6 +217,7 @@ export class PostsService {
                 id:        p.id,
                 authorId:  p.author.id,
                 username:  p.author.username!,
+                ...(p.title ? { title: p.title } : {}),
                 ...(p.imageUrl ? { imageUrl: p.imageUrl } : {}),
                 avatarUrl: p.author.avatarUrl || '',
                 caption:   p.body,
@@ -275,7 +276,7 @@ export class PostsService {
                 id: p.id,
                 authorId: p.author.id,
                 username: p.author.username!,
-                title: p.title ?? '',
+                title: p.title,
                 ...(p.imageUrl ? { imageUrl: p.imageUrl } : {}),
                 avatarUrl: p.author.avatarUrl || '',
                 caption: p.body,
@@ -302,7 +303,7 @@ export class PostsService {
     authorId: string;
     avatarUrl:   string;
     imageUrl?:   string;
-    title:       string;
+    title?:      string;
     caption:     string;
     timestamp:   string;
     stars:       number;
@@ -354,7 +355,7 @@ export class PostsService {
 
       avatarUrl: post.author.avatarUrl ?? '',
       ...(post.imageUrl ? { imageUrl: post.imageUrl } : {}),
-      title:     post.title ?? '',
+      ...(post.loungeId || post.title ? { title: post.title } : {}),
       caption:   post.body,
       timestamp: post.createdAt.toISOString(),
       stars:     post.likes,

--- a/backend/src/posts/post.service.ts
+++ b/backend/src/posts/post.service.ts
@@ -275,6 +275,7 @@ export class PostsService {
                 id: p.id,
                 authorId: p.author.id,
                 username: p.author.username!,
+                title: p.title ?? '',
                 ...(p.imageUrl ? { imageUrl: p.imageUrl } : {}),
                 avatarUrl: p.author.avatarUrl || '',
                 caption: p.body,
@@ -301,6 +302,7 @@ export class PostsService {
     authorId: string;
     avatarUrl:   string;
     imageUrl?:   string;
+    title:       string;
     caption:     string;
     timestamp:   string;
     stars:       number;
@@ -352,6 +354,7 @@ export class PostsService {
 
       avatarUrl: post.author.avatarUrl ?? '',
       ...(post.imageUrl ? { imageUrl: post.imageUrl } : {}),
+      title:     post.title ?? '',
       caption:   post.body,
       timestamp: post.createdAt.toISOString(),
       stars:     post.likes,


### PR DESCRIPTION
## Summary
- Display only post titles on lounge pages
- Add lounge post detail page for viewing full body
- Include post title in lounge post API responses

## Testing
- `npm run lint` (fails: Fast refresh only works when a file only exports components...)
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6894e691bc408327ad8974619625b5b2