### PR TITLE
Require captions when posting

### DIFF
--- a/astrogram/src/components/UploadForm/UploadForm.tsx
+++ b/astrogram/src/components/UploadForm/UploadForm.tsx
@@ -10,6 +10,7 @@ const UploadForm: React.FC = () => {
   const [preview, setPreview] = useState<string | null>(null)
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
+  const [captionError, setCaptionError] = useState<string | null>(null)
   const navigate = useNavigate()
 
 
@@ -38,6 +39,11 @@ const UploadForm: React.FC = () => {
   const handleSubmit = async (e: FormEvent) => {
     e.preventDefault()
     setError(null)
+    if (!caption.trim()) {
+      setCaptionError('Caption is required')
+      return
+    }
+    setCaptionError(null)
     setLoading(true)
 
     try {
@@ -90,10 +96,16 @@ const UploadForm: React.FC = () => {
         <textarea
           rows={3}
           value={caption}
-          onChange={(e) => setCaption(e.target.value)}
+          onChange={(e) => {
+            setCaption(e.target.value)
+            if (captionError && e.target.value.trim()) setCaptionError(null)
+          }}
           placeholder="Describe your image..."
           className="w-full px-4 py-2 bg-gray-700 placeholder-gray-500 rounded-lg focus:ring-2 focus:ring-teal-400 outline-none text-gray-100"
         />
+        {captionError && (
+          <p className="mt-1 text-sm text-red-500">{captionError}</p>
+        )}
       </div>
 
       {/* File upload */}

--- a/backend/src/posts/post.service.ts
+++ b/backend/src/posts/post.service.ts
@@ -60,6 +60,10 @@ export class PostsService {
             throw new BadRequestException('Title and body are required for lounge posts')
         }
 
+        if (!dto.loungeId && !dto.body?.trim()) {
+            throw new BadRequestException('Caption is required')
+        }
+
         if (!dto.loungeId && dto.body && dto.body.length > 314) {
             throw new BadRequestException('Post body must be 314 characters or fewer')
         }


### PR DESCRIPTION
## Summary
- block uploads without a caption and show inline error
- refuse posts without captions on the backend

## Testing
- `npm test`
- `npx eslint src/posts/post.service.ts`
- `npm run lint` (fails: Fast refresh only works..., Unexpected any...)
- `npm test` (frontend: Missing script "test")
- `npm run lint` (backend: 164 problems)


------
https://chatgpt.com/codex/tasks/task_e_68952ee1e4408327882b299e632e75a9