### PR TITLE
feat: add validation decorators and global pipe

### DIFF
--- a/backend/src/comments/dto/create-comment.dto.ts
+++ b/backend/src/comments/dto/create-comment.dto.ts
@@ -1,4 +1,10 @@
+import { IsOptional, IsString } from 'class-validator';
+
 export class CreateCommentDto {
+  @IsString()
   text: string;
+
+  @IsOptional()
+  @IsString()
   parentId?: string;
 }

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -5,7 +5,7 @@ import * as express from 'express';
 import * as path from 'path';
 import { Request, Response } from 'express';
 import { ExpressAdapter } from '@nestjs/platform-express';
-import { Logger } from '@nestjs/common';
+import { Logger, ValidationPipe } from '@nestjs/common';
 import * as cookieParser from 'cookie-parser';
 
 
@@ -18,6 +18,7 @@ async function bootstrap() {
 
   const server = express();
   const app = await NestFactory.create(AppModule, new ExpressAdapter(server));
+  app.useGlobalPipes(new ValidationPipe({ whitelist: true }));
   app.use(cookieParser());
   const isProduction = process.env.NODE_ENV === 'production';
 

--- a/backend/src/posts/dto/create-post.dto.ts
+++ b/backend/src/posts/dto/create-post.dto.ts
@@ -1,13 +1,22 @@
+import { IsOptional, IsString } from 'class-validator';
+
 export class CreatePostDto {
-    /** Short headline for the post */
-    title?: string
+  /** Short headline for the post */
+  @IsString()
+  @IsOptional()
+  title?: string;
 
-    /** Body / caption text */
-    body: string
+  /** Body / caption text */
+  @IsString()
+  body: string;
 
-    /** Optional link to an image */
-    imageUrl?: string
+  /** Optional link to an image */
+  @IsString()
+  @IsOptional()
+  imageUrl?: string;
 
-    /** Lounge to post into */
-    loungeId?: string
-  }
+  /** Lounge to post into */
+  @IsString()
+  @IsOptional()
+  loungeId?: string;
+}


### PR DESCRIPTION
## Summary
- validate post and comment DTOs using class-validator
- enable global ValidationPipe with property whitelisting

## Testing
- `npm test` *(fails: Cannot find module 'class-validator')*
- `npx eslint "{src,apps,libs,test}/**/*.ts"` *(fails: many lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_689531456a048327b08d36df2c5fae86