### PR TITLE
Encrypt stored user emails and add migration

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -17,7 +17,8 @@
     "test:watch": "jest --watch",
     "test:cov": "jest --coverage",
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
-    "test:e2e": "jest --config ./test/jest-e2e.json"
+    "test:e2e": "jest --config ./test/jest-e2e.json",
+    "backfill:emails": "ts-node prisma/scripts/backfillEmails.ts"
   },
   "dependencies": {
     "@nestjs/axios": "^4.0.0",

--- a/backend/prisma/migrations/20250715174435_email_encryption/migration.sql
+++ b/backend/prisma/migrations/20250715174435_email_encryption/migration.sql
@@ -1,0 +1,5 @@
+-- Alter User table to support encrypted emails
+ALTER TABLE "User" RENAME COLUMN "email" TO "emailEncrypted";
+ALTER TABLE "User" ADD COLUMN "emailHash" TEXT;
+DROP INDEX IF EXISTS "User_email_key";
+CREATE UNIQUE INDEX "User_emailHash_key" ON "User"("emailHash");

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -21,7 +21,8 @@ enum NotificationType {
 
 model User {
   id                String            @id @default(uuid())
-  email             String            @unique
+  emailEncrypted    String
+  emailHash         String            @unique
   name              String?
   provider          String
   providerId        String

--- a/backend/prisma/scripts/backfillEmails.ts
+++ b/backend/prisma/scripts/backfillEmails.ts
@@ -1,0 +1,26 @@
+import { PrismaClient } from '@prisma/client';
+import { encryptEmail, hashEmail } from '../../src/utils/crypto';
+
+const prisma = new PrismaClient();
+
+async function main() {
+  const users = await prisma.user.findMany({ select: { id: true, emailEncrypted: true } });
+  for (const user of users) {
+    if (!user.emailEncrypted) continue;
+    const encrypted = encryptEmail(user.emailEncrypted);
+    const hash = hashEmail(user.emailEncrypted);
+    await prisma.user.update({
+      where: { id: user.id },
+      data: { emailEncrypted: encrypted, emailHash: hash },
+    });
+  }
+}
+
+main()
+  .catch((e) => {
+    console.error(e);
+    process.exit(1);
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
+  });

--- a/backend/src/users/users.service.ts
+++ b/backend/src/users/users.service.ts
@@ -3,6 +3,7 @@ import { PrismaService } from '../prisma/prisma.service';
 import { UserDto } from './dto/user.dto';
 import { SupabaseClient } from '@supabase/supabase-js';
 import { StorageService } from 'src/storage/storage.service';
+import { decryptEmail } from '../utils/crypto';
 
 @Injectable()
 export class UsersService {
@@ -16,7 +17,7 @@ export class UsersService {
       where: { id: userId },
       select: {
         id: true,
-        email: true,
+        emailEncrypted: true,
         username: true,
         avatarUrl: true,
         profileComplete: true,     // ← add this
@@ -159,7 +160,7 @@ export class UsersService {
       where: { username },
       select: {
         id: true,
-        email: true,
+        emailEncrypted: true,
         username: true,
         avatarUrl: true,
         profileComplete: true,
@@ -236,7 +237,7 @@ export class UsersService {
 
   private toDto(user: {
     id: string;
-    email: string;
+    emailEncrypted: string | null;
     username?: string | null;
     avatarUrl?: string | null;
     profileComplete: boolean;
@@ -244,7 +245,7 @@ export class UsersService {
   }): UserDto {
     return {
       id:              user.id,
-      email:           user.email,
+      email:           user.emailEncrypted ? decryptEmail(user.emailEncrypted) : '',
       username:        user.username ?? undefined,
       avatarUrl:       user.avatarUrl ?? undefined,
       profileComplete: user.profileComplete,

--- a/backend/src/utils/crypto.ts
+++ b/backend/src/utils/crypto.ts
@@ -1,0 +1,30 @@
+import * as crypto from 'crypto';
+
+const ALGORITHM = 'aes-256-ctr';
+const SECRET = crypto
+  .createHash('sha256')
+  .update(String(process.env.EMAIL_ENCRYPTION_KEY || 'default_secret'))
+  .digest();
+
+export function encryptEmail(email: string): string {
+  const iv = crypto.randomBytes(16);
+  const cipher = crypto.createCipheriv(ALGORITHM, SECRET, iv);
+  const encrypted = Buffer.concat([
+    cipher.update(email, 'utf8'),
+    cipher.final(),
+  ]);
+  return iv.toString('hex') + ':' + encrypted.toString('hex');
+}
+
+export function decryptEmail(encrypted: string): string {
+  const [ivHex, contentHex] = encrypted.split(':');
+  const iv = Buffer.from(ivHex, 'hex');
+  const content = Buffer.from(contentHex, 'hex');
+  const decipher = crypto.createDecipheriv(ALGORITHM, SECRET, iv);
+  const decrypted = Buffer.concat([decipher.update(content), decipher.final()]);
+  return decrypted.toString('utf8');
+}
+
+export function hashEmail(email: string): string {
+  return crypto.createHash('sha256').update(email).digest('hex');
+}


### PR DESCRIPTION
## Summary
- store user emails as encrypted text and hash
- update auth and user services to use encrypted email storage
- add migration and backfill script for existing emails

## Testing
- `npm test`
- `npm run lint` *(fails: Unsafe member access and assignment warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68953134ae388327a54c5621281bce13