### PR TITLE
chore: specify backend rootDir

### DIFF
--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -9,6 +9,7 @@
     "target": "ES2023",
     "sourceMap": true,
     "outDir": "./dist",
+    "rootDir": "src",
     "baseUrl": "./",
     "incremental": true,
     "skipLibCheck": true,
@@ -17,5 +18,6 @@
     "noImplicitAny": false,
     "strictBindCallApply": false,
     "noFallthroughCasesInSwitch": false
-  }
+  },
+  "include": ["src/**/*.ts"]
 }


### PR DESCRIPTION
## Summary
- set backend TypeScript rootDir to src and restrict includes to source files

## Testing
- `npm test`
- `npx tsc -p tsconfig.build.json`
- `docker build -t astrosocial-app .` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6896870f86848327b2662379af6f6d3a