### PR TITLE
chore: specify backend rootDir

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -9,6 +9,7 @@
     "build": "nest build",
     "format": "prettier --write \"src/**/*.ts\" \"test/**/*.ts\"",
     "start": "nest start",
+    "prestart:dev": "tsc -b tsconfig.build.json --force",
     "start:dev": "nest start --watch",
     "start:debug": "nest start --debug --watch",
     "start:prod": "node dist/main",

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -9,6 +9,7 @@
     "target": "ES2023",
     "sourceMap": true,
     "outDir": "./dist",
+    "rootDir": "src",
     "baseUrl": "./",
     "incremental": true,
     "skipLibCheck": true,
@@ -17,5 +18,6 @@
     "noImplicitAny": false,
     "strictBindCallApply": false,
     "noFallthroughCasesInSwitch": false
-  }
+  },
+  "include": ["src/**/*.ts"]
 }


### PR DESCRIPTION
## Summary
- set backend TypeScript rootDir to src and restrict includes to source files
- prebuild backend before starting dev server to ensure dist/main.js is present

## Testing
- `npm test`
- `npm run prestart:dev`
- `ls dist | grep main.js`


------
https://chatgpt.com/codex/tasks/task_e_6896870f86848327b2662379af6f6d3a