### PR TITLE
chore: specify backend rootDir

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -9,7 +9,7 @@
     "build": "nest build",
     "format": "prettier --write \"src/**/*.ts\" \"test/**/*.ts\"",
     "start": "nest start",
-    "start:dev": "nest start --watch",
+    "start:dev": "npm run build && nest start --watch",
     "start:debug": "nest start --debug --watch",
     "start:prod": "node dist/main",
     "lint": "eslint \"{src,apps,libs,test}/**/*.ts\" --fix",

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -9,6 +9,7 @@
     "target": "ES2023",
     "sourceMap": true,
     "outDir": "./dist",
+    "rootDir": "src",
     "baseUrl": "./",
     "incremental": true,
     "skipLibCheck": true,
@@ -17,5 +18,6 @@
     "noImplicitAny": false,
     "strictBindCallApply": false,
     "noFallthroughCasesInSwitch": false
-  }
+  },
+  "include": ["src/**/*.ts"]
 }


### PR DESCRIPTION
## Summary
- set backend TypeScript rootDir to src and restrict includes to source files
- build backend before launching dev server to ensure dist/main.js is available

## Testing
- `npm test` *(fails: process hung; no tests executed)*
- `npm run start:dev` *(fails: process hung before logging output)*

------
https://chatgpt.com/codex/tasks/task_e_6896870f86848327b2662379af6f6d3a