### PR TITLE
Expose user role to client

### DIFF
--- a/astrogram/src/App.tsx
+++ b/astrogram/src/App.tsx
@@ -18,6 +18,7 @@ import LoungePage from './pages/LoungePage'
 import LoungesPage from './pages/LoungesPage'
 import LoungePostPage from './pages/LoungePostPage'
 import LoungePostDetailPage from './pages/LoungePostDetailPage'
+import AdminPage from './pages/AdminPage'
 
 
 
@@ -61,6 +62,7 @@ const App: React.FC = () => {
             <Route path="/completeProfile" element={<CompleteProfilePage />} />
             <Route path="/profile" element={<Navigate to="/profile/posts" replace />} />
             <Route path="/profile/:tab" element={<ProfilePage />} />
+            <Route path="/admin" element={<AdminPage />} />
             <Route
               path="/weather"
               element={

--- a/astrogram/src/App.tsx
+++ b/astrogram/src/App.tsx
@@ -10,6 +10,7 @@ import SignupPage from './pages/SignupPage';
 import AuthSuccessPage from './pages/AuthSuccessPage';
 import CompleteProfilePage from './pages/CompleteProfilePage'
 import { RequireProfileCompletion } from "./components/auth/RequireProfileCompletion";
+import RequireAdmin from './components/auth/RequireAdmin';
 import PostPage from './pages/PostPage'
 import NotificationsPage from './pages/NotificationsPage'
 import ProfilePage from './pages/ProfilePage'
@@ -56,13 +57,16 @@ const App: React.FC = () => {
           <Route path="/lounge" element={<LoungesPage />} />
           <Route path="/lounge/:loungeName" element={<LoungePage />} />
           <Route path="/lounge/:loungeName/posts/:postId" element={<LoungePostDetailPage />} />
-          <Route element={<RequireProfileCompletion />}>
+          <Route element={<RequireProfileCompletion />}> 
             <Route path="/lounge/:loungeName/post" element={<LoungePostPage />} />
             <Route path="/upload" element={<UploadForm />} />
             <Route path="/completeProfile" element={<CompleteProfilePage />} />
             <Route path="/profile" element={<Navigate to="/profile/posts" replace />} />
             <Route path="/profile/:tab" element={<ProfilePage />} />
-            <Route path="/admin" element={<AdminPage />} />
+            <Route element={<RequireAdmin />}> 
+              <Route path="/admin" element={<Navigate to="/admin/lounge" replace />} />
+              <Route path="/admin/:tab" element={<AdminPage />} />
+            </Route>
             <Route
               path="/weather"
               element={

--- a/astrogram/src/components/Navbar/Navbar.tsx
+++ b/astrogram/src/components/Navbar/Navbar.tsx
@@ -185,6 +185,15 @@ const Navbar = () => {
             >
               Settings
             </Link>
+            {user?.role === 'ADMIN' && (
+              <Link
+                to="/admin"
+                onClick={() => setSideMenuOpen(false)}
+                className="block mb-1 text-lg font-semibold"
+              >
+                Admin
+              </Link>
+            )}
           </div>
           <div className="absolute bottom-0 left-0 w-full p-4 text-sm space-y-1">
             <Link to="/terms" className="block">Terms and Conditions</Link>

--- a/astrogram/src/components/Navbar/Navbar.tsx
+++ b/astrogram/src/components/Navbar/Navbar.tsx
@@ -187,7 +187,7 @@ const Navbar = () => {
             </Link>
             {user?.role === 'ADMIN' && (
               <Link
-                to="/admin"
+                to="/admin/lounge"
                 onClick={() => setSideMenuOpen(false)}
                 className="block mb-1 text-lg font-semibold"
               >

--- a/astrogram/src/components/auth/RequireAdmin.tsx
+++ b/astrogram/src/components/auth/RequireAdmin.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import { Navigate, Outlet } from 'react-router-dom';
+import { useAuth } from '../../contexts/AuthContext';
+
+const RequireAdmin: React.FC = () => {
+  const { user } = useAuth();
+  if (!user) {
+    return <Navigate to="/signup" replace />;
+  }
+  if (user.role !== 'ADMIN') {
+    return <Navigate to="/" replace />;
+  }
+  return <Outlet />;
+};
+
+export default RequireAdmin;

--- a/astrogram/src/contexts/AuthContext.tsx
+++ b/astrogram/src/contexts/AuthContext.tsx
@@ -11,10 +11,10 @@ import { apiFetch, setAccessToken, followLounge, unfollowLounge } from "../lib/a
 
 export interface User {
   id: string;
-  email: string;
   username?: string;
   avatarUrl?: string;
   profileComplete: boolean;
+  role: string;
   followedLounges?: string[];
 }
 
@@ -57,6 +57,10 @@ export const AuthProvider: React.FC<{ children: ReactNode }> = ({ children }) =>
       setLoading(false);
     }
   }, []);
+
+  useEffect(() => {
+    console.log('AuthContext user', user);
+  }, [user]);
 
   const login = async (accessToken: string) => {
     // 1) store new access token

--- a/astrogram/src/lib/api.tsx
+++ b/astrogram/src/lib/api.tsx
@@ -153,6 +153,11 @@ export async function unfollowLounge(name: string) {
   );
 }
 
+export async function createLounge(form: FormData) {
+  const res = await apiFetch(`${API_BASE}/lounges`, { method: 'POST', body: form }, false);
+  return res.json();
+}
+
 
 export type InteractionType = 'like' | 'share' | 'repost';
 

--- a/astrogram/src/pages/AdminPage.tsx
+++ b/astrogram/src/pages/AdminPage.tsx
@@ -1,7 +1,129 @@
-import React from 'react';
+import React, { useState } from 'react';
+import { Link, useParams } from 'react-router-dom';
+import { createLounge } from '../lib/api';
 
-const AdminPage: React.FC = () => (
-  <div className="pt-4">congrats you are an admin</div>
-);
+const tabClasses =
+  'whitespace-nowrap py-2 px-1 border-b-2 font-bold text-sm hover:no-underline transition-colors duration-200';
+
+const AdminPage: React.FC = () => {
+  const { tab } = useParams<{ tab?: string }>();
+  const active: 'lounge' | 'users' | 'posts' =
+    tab === 'users' ? 'users' : tab === 'posts' ? 'posts' : 'lounge';
+
+  const [name, setName] = useState('');
+  const [description, setDescription] = useState('');
+  const [profile, setProfile] = useState<File | null>(null);
+  const [banner, setBanner] = useState<File | null>(null);
+  const [message, setMessage] = useState<string | null>(null);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    const form = new FormData();
+    form.append('name', name);
+    form.append('description', description);
+    if (profile) form.append('profile', profile);
+    if (banner) form.append('banner', banner);
+    try {
+      await createLounge(form);
+      setMessage('Lounge created successfully');
+      setName('');
+      setDescription('');
+      setProfile(null);
+      setBanner(null);
+    } catch (err) {
+      console.error(err);
+      setMessage('Failed to create lounge');
+    }
+  };
+
+  return (
+    <div className="p-4 max-w-2xl mx-auto text-gray-200">
+      <div className="border-b border-gray-700 mb-4 pt-4">
+        <nav className="-mb-px flex justify-center space-x-8" aria-label="Admin tabs">
+          <Link
+            to="/admin/lounge"
+            className={`${tabClasses} ${
+              active === 'lounge'
+                ? 'border-brand text-white'
+                : 'border-transparent text-white hover:text-gray-300 hover:border-gray-300'
+            }`}
+          >
+            Lounge
+          </Link>
+          <Link
+            to="/admin/users"
+            className={`${tabClasses} ${
+              active === 'users'
+                ? 'border-brand text-white'
+                : 'border-transparent text-white hover:text-gray-300 hover:border-gray-300'
+            }`}
+          >
+            Users
+          </Link>
+          <Link
+            to="/admin/posts"
+            className={`${tabClasses} ${
+              active === 'posts'
+                ? 'border-brand text-white'
+                : 'border-transparent text-white hover:text-gray-300 hover:border-gray-300'
+            }`}
+          >
+            Posts
+          </Link>
+        </nav>
+      </div>
+
+      {active === 'lounge' && (
+        <form onSubmit={handleSubmit} className="space-y-4">
+          {message && <div>{message}</div>}
+          <div>
+            <label className="block mb-1 text-sm">Name</label>
+            <input
+              type="text"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              required
+              className="w-full p-2 rounded bg-gray-800 border border-gray-700"
+            />
+          </div>
+          <div>
+            <label className="block mb-1 text-sm">Description</label>
+            <textarea
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              required
+              className="w-full p-2 rounded bg-gray-800 border border-gray-700"
+            />
+          </div>
+          <div>
+            <label className="block mb-1 text-sm">Profile Image</label>
+            <input
+              type="file"
+              accept="image/*"
+              onChange={(e) => setProfile(e.target.files?.[0] || null)}
+            />
+          </div>
+          <div>
+            <label className="block mb-1 text-sm">Banner Image</label>
+            <input
+              type="file"
+              accept="image/*"
+              onChange={(e) => setBanner(e.target.files?.[0] || null)}
+            />
+          </div>
+          <button
+            type="submit"
+            className="px-4 py-2 bg-brand text-white rounded"
+          >
+            Create Lounge
+          </button>
+        </form>
+      )}
+
+      {active === 'users' && <div>User management coming soon.</div>}
+      {active === 'posts' && <div>Post moderation coming soon.</div>}
+    </div>
+  );
+};
 
 export default AdminPage;

--- a/astrogram/src/pages/AdminPage.tsx
+++ b/astrogram/src/pages/AdminPage.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+const AdminPage: React.FC = () => (
+  <div className="pt-4">congrats you are an admin</div>
+);
+
+export default AdminPage;

--- a/backend/src/auth/jwt-refresh.strategy.ts
+++ b/backend/src/auth/jwt-refresh.strategy.ts
@@ -1,13 +1,21 @@
 // src/auth/strategies/jwt-refresh.strategy.ts
 import { Injectable, UnauthorizedException, Logger } from '@nestjs/common';
-import { PassportStrategy }                          from '@nestjs/passport';
-import { Strategy, ExtractJwt }                      from 'passport-jwt';
-import { ConfigService }                             from '@nestjs/config';
-import { UsersService }                              from '../users/users.service';
-import { JwtPayload }                                from './jwt.strategy'; // or wherever you keep that interface
+import { PassportStrategy } from '@nestjs/passport';
+import { Strategy, ExtractJwt } from 'passport-jwt';
+import { ConfigService } from '@nestjs/config';
+import { UsersService } from '../users/users.service';
+import { JwtPayload } from './jwt.strategy'; // or wherever you keep that interface
+import type { Request } from 'express';
+
+interface RequestWithCookies extends Request {
+  cookies?: Record<string, string>;
+}
 
 @Injectable()
-export class JwtRefreshStrategy extends PassportStrategy(Strategy, 'jwt-refresh') {
+export class JwtRefreshStrategy extends PassportStrategy(
+  Strategy,
+  'jwt-refresh',
+) {
   private readonly logger = new Logger(JwtRefreshStrategy.name);
 
   constructor(
@@ -21,7 +29,7 @@ export class JwtRefreshStrategy extends PassportStrategy(Strategy, 'jwt-refresh'
 
     super({
       jwtFromRequest: ExtractJwt.fromExtractors([
-        (req) => req?.cookies['jid'],
+        (req: RequestWithCookies): string | undefined => req.cookies?.['jid'],
       ]),
       ignoreExpiration: false,
       secretOrKey: secret,
@@ -32,15 +40,18 @@ export class JwtRefreshStrategy extends PassportStrategy(Strategy, 'jwt-refresh'
     // exactly the same logic as your access‐token strategy:
     const user = await this.usersService.findById(payload.sub);
     if (!user) {
-      this.logger.error(`Refresh token invalid – user ${payload.sub} not found`);
+      this.logger.error(
+        `Refresh token invalid – user ${payload.sub} not found`,
+      );
       throw new UnauthorizedException('User not found');
     }
     return {
-      sub:             user.id,
-      email:           user.email,
-      username:        user.username,
-      avatarUrl:       user.avatarUrl,
+      sub: user.id,
+      email: payload.email,
+      username: user.username,
+      avatarUrl: user.avatarUrl,
       profileComplete: user.profileComplete,
+      role: user.role,
     };
   }
 }

--- a/backend/src/auth/jwt-refresh.strategy.ts
+++ b/backend/src/auth/jwt-refresh.strategy.ts
@@ -8,7 +8,7 @@ import { JwtPayload } from './jwt.strategy'; // or wherever you keep that interf
 import type { Request } from 'express';
 
 interface RequestWithCookies extends Request {
-  cookies?: Record<string, string>;
+  cookies: Record<string, string>;
 }
 
 @Injectable()
@@ -29,7 +29,7 @@ export class JwtRefreshStrategy extends PassportStrategy(
 
     super({
       jwtFromRequest: ExtractJwt.fromExtractors([
-        (req: RequestWithCookies): string | undefined => req.cookies?.['jid'],
+        (req: RequestWithCookies): string | null => req.cookies['jid'] ?? null,
       ]),
       ignoreExpiration: false,
       secretOrKey: secret,

--- a/backend/src/lounges/dto/create-lounge.dto.ts
+++ b/backend/src/lounges/dto/create-lounge.dto.ts
@@ -1,4 +1,11 @@
+import { IsNotEmpty, IsString } from 'class-validator';
+
 export class CreateLoungeDto {
+  @IsString()
+  @IsNotEmpty()
   name: string;
+
+  @IsString()
+  @IsNotEmpty()
   description: string;
 }

--- a/backend/src/lounges/lounges.service.ts
+++ b/backend/src/lounges/lounges.service.ts
@@ -42,8 +42,8 @@ export class LoungesService {
           banner,
         );
       }
-    } catch (err: any) {
-      this.logger.error('Failed to upload lounge images', err.stack);
+    } catch (err: unknown) {
+      this.logger.error('Failed to upload lounge images', (err as Error).stack);
       throw new InternalServerErrorException('Could not upload lounge images');
     }
 
@@ -58,19 +58,22 @@ export class LoungesService {
       });
       this.logger.log(`Lounge created with id=${lounge.id}`);
       return lounge;
-    } catch (err: any) {
-      this.logger.error('Failed to create lounge record', err.stack);
+    } catch (err: unknown) {
+      this.logger.error('Failed to create lounge record', (err as Error).stack);
       throw new InternalServerErrorException('Could not create lounge');
     }
   }
 
   async findAll() {
-    console.log('is this not hit at all?')
     this.logger.log('Fetching all lounges');
     const lounges = await this.prisma.lounge.findMany({
       include: {
         _count: { select: { posts: true } },
-        posts: { select: { createdAt: true }, orderBy: { createdAt: 'desc' }, take: 1 },
+        posts: {
+          select: { createdAt: true },
+          orderBy: { createdAt: 'desc' },
+          take: 1,
+        },
       },
     });
 
@@ -93,7 +96,11 @@ export class LoungesService {
       where: { name },
       include: {
         _count: { select: { posts: true } },
-        posts: { select: { createdAt: true }, orderBy: { createdAt: 'desc' }, take: 1 },
+        posts: {
+          select: { createdAt: true },
+          orderBy: { createdAt: 'desc' },
+          take: 1,
+        },
       },
     });
 

--- a/backend/src/users/dto/user.dto.ts
+++ b/backend/src/users/dto/user.dto.ts
@@ -1,13 +1,11 @@
 // import { UserRole } from '@prisma/client';
 
-
 export interface UserDto {
-  id:             string;
-  email:          string;
-  username?:      string;
-  avatarUrl?:     string;
+  id: string;
+  username?: string;
+  avatarUrl?: string;
   profileComplete: boolean;
-  // role:           string;
-  name?:          string;
+  role: string;
+  name?: string;
   followedLounges?: string[];
 }


### PR DESCRIPTION
## Summary
- remove email field from user DTO and API responses
- log user object in AuthContext and conditionally show Admin link
- add placeholder Admin page and route for ADMIN users

## Testing
- `cd backend && npm test`
- `npx eslint src/users/dto/user.dto.ts src/users/users.service.ts src/users/users.controller.ts src/auth/jwt.strategy.ts src/auth/jwt-refresh.strategy.ts`
- `cd astrogram && npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6897a533fca0832786b3bf431a337571