### PR TITLE
fix: ensure backend dev server starts

### DIFF
--- a/backend/nest-cli.json
+++ b/backend/nest-cli.json
@@ -3,6 +3,6 @@
   "collection": "@nestjs/schematics",
   "sourceRoot": "src",
   "compilerOptions": {
-    "deleteOutDir": true
+    "deleteOutDir": false
   }
 }

--- a/backend/src/posts/post.controller.ts
+++ b/backend/src/posts/post.controller.ts
@@ -19,7 +19,7 @@ import { PostsService } from './post.service'
 import { InteractionType } from '@prisma/client'
 import { CreatePostDto } from './dto/create-post.dto'
 import { FileInterceptor } from '@nestjs/platform-express'
-import { OptionalAuthGuard } from 'src/auth/jwt-optional.guard'
+import { OptionalAuthGuard } from '../auth/jwt-optional.guard'
 
 @Controller('api/posts')
 export class PostsController {

--- a/backend/src/posts/post.module.ts
+++ b/backend/src/posts/post.module.ts
@@ -3,7 +3,7 @@ import { Module }         from '@nestjs/common'
 import { PrismaModule }   from '../prisma/prisma.module'
 import { PostsService }   from './post.service'
 import { PostsController }from './post.controller'
-import { StorageService } from 'src/storage/storage.service';
+import { StorageService } from '../storage/storage.service';
 import { SupabaseModule }  from '../supabase/supabase.module';
 import { NotificationsModule } from '../notifications/notifications.module';
 

--- a/backend/src/posts/post.service.ts
+++ b/backend/src/posts/post.service.ts
@@ -11,7 +11,7 @@ import {
 import { PrismaService } from '../prisma/prisma.service'
 import { InteractionType, Post, NotificationType } from '@prisma/client'
 import { CreatePostDto } from './dto/create-post.dto'
-import { StorageService } from 'src/storage/storage.service'
+import { StorageService } from '../storage/storage.service'
 import { NotificationsService } from '../notifications/notifications.service'
 
 

--- a/backend/src/users/users.module.ts
+++ b/backend/src/users/users.module.ts
@@ -3,7 +3,7 @@ import { UsersController } from './users.controller';
 import { UsersService }    from './users.service';
 import { PrismaModule }    from '../prisma/prisma.module';
 import { SupabaseModule }  from '../supabase/supabase.module';
-import { StorageService } from 'src/storage/storage.service';
+import { StorageService } from '../storage/storage.service';
 
 
 @Module({

--- a/backend/src/users/users.service.ts
+++ b/backend/src/users/users.service.ts
@@ -8,7 +8,7 @@ import {
 import { PrismaService } from '../prisma/prisma.service';
 import { UserDto } from './dto/user.dto';
 import { SupabaseClient } from '@supabase/supabase-js';
-import { StorageService } from 'src/storage/storage.service';
+import { StorageService } from '../storage/storage.service';
 
 @Injectable()
 export class UsersService {


### PR DESCRIPTION
## Summary
- Preserve compiled output by disabling Nest's deleteOutDir
- Use relative imports for storage and auth modules so runtime can resolve them

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689b7e2090ac8327961c8f7c2e374184