### PR TITLE
feat(profile): split lounge posts

### DIFF
--- a/backend/src/users/users.service.ts
+++ b/backend/src/users/users.service.ts
@@ -111,7 +111,10 @@ export class UsersService {
     const posts = await this.prisma.post.findMany({
       where: { authorId: userId },
       orderBy: { createdAt: 'desc' },
-      include: { _count: { select: { comments: true } } },
+      include: {
+        _count: { select: { comments: true } },
+        lounge: { select: { name: true } },
+      },
     });
 
     const user = await this.prisma.user.findUnique({
@@ -126,6 +129,9 @@ export class UsersService {
       avatarUrl: user?.avatarUrl || '',
       ...(p.imageUrl ? { imageUrl: p.imageUrl } : {}),
       caption: p.body,
+      title: p.title,
+      loungeId: p.loungeId || undefined,
+      loungeName: p.lounge?.name,
       timestamp: p.createdAt.toISOString(),
       stars: p.likes,
       comments: p._count.comments,
@@ -184,7 +190,10 @@ export class UsersService {
     const posts = await this.prisma.post.findMany({
       where: { authorId: user.id },
       orderBy: { createdAt: 'desc' },
-      include: { _count: { select: { comments: true } } },
+      include: {
+        _count: { select: { comments: true } },
+        lounge: { select: { name: true } },
+      },
     });
 
     return posts.map((p) => ({
@@ -194,6 +203,9 @@ export class UsersService {
       avatarUrl: user.avatarUrl || '',
       ...(p.imageUrl ? { imageUrl: p.imageUrl } : {}),
       caption: p.body,
+      title: p.title,
+      loungeId: p.loungeId || undefined,
+      loungeName: p.lounge?.name,
       timestamp: p.createdAt.toISOString(),
       stars: p.likes,
       comments: p._count.comments,


### PR DESCRIPTION
## Summary
- separate general and lounge posts on profile page
- style lounge posts like lounge feed and add delete menu
- include lounge metadata in user post APIs

## Testing
- `npm run lint` (frontend)
- `npm run build` (frontend)
- `npm test` (backend)
- `npm run lint` (backend) *(fails: unsafe any usage)*

------
https://chatgpt.com/codex/tasks/task_e_689b89e366b48327a8ef8beae8bea172