### PR TITLE
Add placeholder search page with under-construction image

### DIFF
--- a/astrogram/public/under-construction.svg
+++ b/astrogram/public/under-construction.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200">
+  <rect width="200" height="200" fill="#1f2937" />
+  <polygon points="100,20 190,180 10,180" fill="#FBBF24" />
+  <text x="100" y="135" font-size="24" text-anchor="middle" fill="#1f2937" font-family="Arial, sans-serif">Under</text>
+  <text x="100" y="165" font-size="24" text-anchor="middle" fill="#1f2937" font-family="Arial, sans-serif">Construction</text>
+</svg>

--- a/astrogram/src/App.tsx
+++ b/astrogram/src/App.tsx
@@ -20,6 +20,7 @@ import LoungesPage from './pages/LoungesPage'
 import LoungePostPage from './pages/LoungePostPage'
 import LoungePostDetailPage from './pages/LoungePostDetailPage'
 import AdminPage from './pages/AdminPage'
+import SearchPage from './pages/SearchPage'
 
 
 
@@ -57,7 +58,8 @@ const App: React.FC = () => {
           <Route path="/lounge" element={<LoungesPage />} />
           <Route path="/lounge/:loungeName" element={<LoungePage />} />
           <Route path="/lounge/:loungeName/posts/:postId" element={<LoungePostDetailPage />} />
-          <Route element={<RequireProfileCompletion />}> 
+          <Route path="/search" element={<SearchPage />} />
+          <Route element={<RequireProfileCompletion />}>
             <Route path="/lounge/:loungeName/post" element={<LoungePostPage />} />
             <Route path="/upload" element={<UploadForm />} />
             <Route path="/completeProfile" element={<CompleteProfilePage />} />

--- a/astrogram/src/pages/SearchPage.tsx
+++ b/astrogram/src/pages/SearchPage.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+
+const SearchPage: React.FC = () => {
+  return (
+    <div className="flex flex-col items-center justify-center h-full text-center">
+      <img
+        src="/under-construction.svg"
+        alt="Under construction"
+        className="w-64 h-64 mb-4"
+      />
+      <h1 className="text-2xl font-semibold">Search is under construction</h1>
+    </div>
+  );
+};
+
+export default SearchPage;


### PR DESCRIPTION
## Summary
- add Search page displaying an under-construction image
- wire up `/search` route

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689bac589aac8327a80609f26f0e28f8