### PR TITLE
Add 404 page with home redirect

### DIFF
--- a/astrogram/src/App.tsx
+++ b/astrogram/src/App.tsx
@@ -20,6 +20,7 @@ import LoungesPage from './pages/LoungesPage'
 import LoungePostPage from './pages/LoungePostPage'
 import LoungePostDetailPage from './pages/LoungePostDetailPage'
 import AdminPage from './pages/AdminPage'
+import NotFoundPage from './pages/NotFoundPage'
 
 
 
@@ -80,6 +81,7 @@ const App: React.FC = () => {
               }
             />
           </Route>
+          <Route path="*" element={<NotFoundPage />} />
         </Routes>
       </main>
 

--- a/astrogram/src/pages/NotFoundPage.tsx
+++ b/astrogram/src/pages/NotFoundPage.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+
+const NotFoundPage: React.FC = () => {
+  return (
+    <div className="flex flex-col items-center justify-center py-20 text-center gap-4">
+      <h1 className="text-4xl font-bold">404 - Page Not Found</h1>
+      <p className="text-gray-400">The page you are looking for does not exist.</p>
+      <Link
+        to="/"
+        className="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-500"
+      >
+        Return Home
+      </Link>
+    </div>
+  );
+};
+
+export default NotFoundPage;


### PR DESCRIPTION
## Summary
- add NotFoundPage component to display a friendly 404 message and home link
- wire wildcard route in App.tsx to render NotFoundPage for unknown paths

## Testing
- `npm test` (frontend: missing script)
- `npm run lint` (frontend)
- `npm test` (backend)
- `npm run lint` (backend; reports many lint errors)


------
https://chatgpt.com/codex/tasks/task_e_689bac770a148327b5b206f64fd6bc9c