### PR TITLE
Redirect to sign in on session refresh failure

### DIFF
--- a/astrogram/src/components/SessionExpiredModal.tsx
+++ b/astrogram/src/components/SessionExpiredModal.tsx
@@ -6,20 +6,14 @@ interface SessionExpiredModalProps {
 
 const SessionExpiredModal: React.FC<SessionExpiredModalProps> = ({ onClose }) => {
   const handleRefresh = () => {
+    // Close the modal and redirect the user to sign in so they can
+    // re‑authenticate. Attempting to reload the page simply brought
+    // the modal back, so instead send them to the signup page.
     onClose();
 
-    try {
-      if (typeof window !== 'undefined' && typeof window.location.reload === 'function') {
-        window.location.reload();
-      } else {
-        window.location.href = '/signup';
-      }
-    } catch {
+    if (typeof window !== 'undefined') {
       window.location.href = '/signup';
     }
-
-    window.location.reload();
-
   };
 
   return (


### PR DESCRIPTION
## Summary
- Redirect expired sessions to signup when refresh fails

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689bad258e308327a9e08e45c22b5ea7