### PR TITLE
feat: expose repost state in feed

### DIFF
--- a/astrogram/src/components/PostCard/PostCard.tsx
+++ b/astrogram/src/components/PostCard/PostCard.tsx
@@ -17,8 +17,10 @@ export interface PostCardProps {
   stars?: number;
   comments?: number;
   shares?: number;
+  reposts?: number;
   avatarUrl: string;
   likedByMe?: boolean;
+  repostedByMe?: boolean;
   onDeleted?: (id: string) => void;
 }
 
@@ -45,7 +47,8 @@ const PostCard: React.FC<PostCardProps> = ({
   const [starCount, setStarCount] = useState(stars);
   const [commentCount] = useState(comments);
   const [shareCount, setShareCount] = useState(shares);
-  const [reposted, setReposted] = useState(false);
+  const [reposted, setReposted] = useState(Boolean(repostedByMe));
+  const [repostCount, setRepostCount] = useState(reposts || 0);
   const [saved, setSaved] = useState(false);
   const [menuOpen, setMenuOpen] = useState(false);
   const menuRef = useRef<HTMLDivElement>(null);
@@ -96,10 +99,10 @@ const PostCard: React.FC<PostCardProps> = ({
   const handleRepost = async () => {
     if (reposted) return;
       try {
-        await repostPost(id);
-        setShareCount(prev => prev); // leave shareCount alone
+        const { count } = await repostPost(id);
+        setRepostCount(count);
         setReposted(true);
-        // if you want to show repost count separately, add another state
+        setShareCount(prev => prev); // share count unaffected by repost
       } catch (err: unknown) {
         console.error("Failed to repost:", err);
       }
@@ -227,7 +230,7 @@ const PostCard: React.FC<PostCardProps> = ({
               className="btn-unstyled btn-action hover:text-green-400"
             >
               <Repeat2 className="w-5 h-5" />
-              <span>{reposted ? 1 : 0}</span>
+              <span>{repostCount}</span>
             </button>
 
             {/* Comment */}

--- a/astrogram/src/components/PostCard/PostCard.tsx
+++ b/astrogram/src/components/PostCard/PostCard.tsx
@@ -34,7 +34,9 @@ const PostCard: React.FC<PostCardProps> = ({
   stars = 0,
   comments = 0,
   shares = 0,
+  reposts = 0,
   likedByMe,
+  repostedByMe,
   authorId,
   onDeleted
 }) => {
@@ -48,7 +50,7 @@ const PostCard: React.FC<PostCardProps> = ({
   const [commentCount] = useState(comments);
   const [shareCount, setShareCount] = useState(shares);
   const [reposted, setReposted] = useState(Boolean(repostedByMe));
-  const [repostCount, setRepostCount] = useState(reposts || 0);
+  const [repostCount, setRepostCount] = useState(reposts);
   const [saved, setSaved] = useState(false);
   const [menuOpen, setMenuOpen] = useState(false);
   const menuRef = useRef<HTMLDivElement>(null);

--- a/astrogram/src/pages/PostPage.tsx
+++ b/astrogram/src/pages/PostPage.tsx
@@ -50,8 +50,10 @@ const PostPage: React.FC = () => {
           stars:      data.stars,
           comments:   data.comments,
           shares:     data.shares,
-          likedByMe: data.likedByMe,
-          authorId: data.authorId
+          reposts:    data.reposts,
+          likedByMe:  data.likedByMe,
+          repostedByMe: data.repostedByMe,
+          authorId:   data.authorId
         }
         setPost(p)
       })

--- a/backend/src/posts/dto/feed.dto.ts
+++ b/backend/src/posts/dto/feed.dto.ts
@@ -1,0 +1,23 @@
+export interface FeedPostDto {
+  id: string;
+  authorId: string;
+  username: string;
+  avatarUrl: string;
+  caption: string;
+  timestamp: string;
+  stars: number;
+  comments: number;
+  shares: number;
+  reposts: number;
+  likedByMe: boolean;
+  repostedByMe: boolean;
+  title?: string;
+  imageUrl?: string;
+}
+
+export interface FeedResponseDto {
+  posts: FeedPostDto[];
+  total: number;
+  page: number;
+  limit: number;
+}

--- a/backend/src/posts/post.controller.ts
+++ b/backend/src/posts/post.controller.ts
@@ -20,6 +20,7 @@ import { InteractionType } from '@prisma/client'
 import { CreatePostDto } from './dto/create-post.dto'
 import { FileInterceptor } from '@nestjs/platform-express'
 import { OptionalAuthGuard } from '../auth/jwt-optional.guard'
+import { FeedResponseDto } from './dto/feed.dto'
 
 @Controller('api/posts')
 export class PostsController {
@@ -37,7 +38,7 @@ export class PostsController {
         @Req() req: any,
         @Query('page') page = '1',
         @Query('limit') limit = '20',
-    ) {
+    ): Promise<FeedResponseDto> {
         const p = parseInt(page, 10) || 1;
         const l = parseInt(limit, 10) || 20;
         this.logger.log(`Fetching public feed (page=${p}, limit=${l})`);


### PR DESCRIPTION
## Summary
- include user repost interactions when building feed
- surface `reposts` count and `repostedByMe` in feed items
- support repost counts in PostCard component

## Testing
- `cd backend && npm test`
- `cd astrogram && npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689bb919cc188327a586bc7be86d7723