### PR TITLE
feat: surface reposts in feed

### DIFF
--- a/astrogram/src/components/PostCard/PostCard.tsx
+++ b/astrogram/src/components/PostCard/PostCard.tsx
@@ -19,6 +19,7 @@ export interface PostCardProps {
   shares?: number;
   avatarUrl: string;
   likedByMe?: boolean;
+  repostedBy?: { id: string; username: string; avatarUrl: string };
   onDeleted?: (id: string) => void;
 }
 
@@ -34,6 +35,7 @@ const PostCard: React.FC<PostCardProps> = ({
   shares = 0,
   likedByMe,
   authorId,
+  repostedBy,
   onDeleted
 }) => {
 
@@ -142,6 +144,21 @@ const PostCard: React.FC<PostCardProps> = ({
   return (
     <div className="w-full py-0 sm:py-2 sm:px-2">
       <div className="bg-white dark:bg-gray-800 text-black dark:text-white rounded-2xl shadow-md hover:shadow-xl transition duration-300 overflow-hidden border border-gray-300 dark:border-gray-700 w-full sm:max-w-2xl sm:mx-auto">
+        {repostedBy && (
+          <div className="px-4 sm:px-6 py-2 text-xs text-gray-500 dark:text-gray-400 flex items-center gap-1 border-b border-gray-200 dark:border-gray-700">
+            <Repeat2 className="w-4 h-4" />
+            <span>
+              Reposted by{' '}
+              <Link
+                to={`/users/${repostedBy.username}/posts`}
+                onClick={(e) => e.stopPropagation()}
+                className="hover:underline"
+              >
+                @{repostedBy.username}
+              </Link>
+            </span>
+          </div>
+        )}
 
         {/* Header */}
         <div className="px-4 sm:px-6 py-4 border-b border-gray-200 dark:border-gray-700 flex justify-between items-center">

--- a/backend/src/posts/dto/feed-response.dto.ts
+++ b/backend/src/posts/dto/feed-response.dto.ts
@@ -1,0 +1,28 @@
+export interface ReposterDto {
+  id: string;
+  username: string;
+  avatarUrl: string;
+}
+
+export interface FeedPostDto {
+  id: string;
+  authorId: string;
+  username: string;
+  title?: string;
+  imageUrl?: string;
+  avatarUrl: string;
+  caption: string;
+  timestamp: string;
+  stars: number;
+  comments: number;
+  shares: number;
+  likedByMe: boolean;
+  repostedBy?: ReposterDto;
+}
+
+export interface FeedResponseDto {
+  posts: FeedPostDto[];
+  total: number;
+  page: number;
+  limit: number;
+}

--- a/backend/src/posts/post.service.spec.ts
+++ b/backend/src/posts/post.service.spec.ts
@@ -1,0 +1,58 @@
+import { PostsService } from './post.service';
+import { InteractionType } from '@prisma/client';
+
+describe('PostsService.getWeightedFeed', () => {
+  it('includes reposted posts with reposter info', async () => {
+    const prisma: any = {
+      post: {
+        findMany: jest.fn().mockResolvedValue([
+          {
+            id: 'p1',
+            author: { id: 'a1', username: 'author', avatarUrl: null },
+            _count: { comments: 0 },
+            interactions: [],
+            title: '',
+            body: 'original',
+            imageUrl: null,
+            likes: 0,
+            shares: 0,
+            reposts: 0,
+            createdAt: new Date('2024-01-01T00:00:00Z')
+          }
+        ])
+      },
+      postInteraction: {
+        findMany: jest.fn().mockResolvedValue([
+          {
+            id: 'r1',
+            createdAt: new Date('2024-01-02T00:00:00Z'),
+            user: { id: 'u2', username: 'reposter', avatarUrl: null },
+            post: {
+              id: 'p1',
+              author: { id: 'a1', username: 'author', avatarUrl: null },
+              _count: { comments: 0 },
+              interactions: [],
+              title: '',
+              body: 'original',
+              imageUrl: null,
+              likes: 0,
+              shares: 0,
+              reposts: 0,
+              createdAt: new Date('2024-01-01T00:00:00Z')
+            }
+          }
+        ])
+      }
+    };
+
+    const service = new PostsService(prisma, {} as any, {} as any);
+    const res = await service.getWeightedFeed('viewer', 1, 20);
+
+    expect(prisma.post.findMany).toHaveBeenCalled();
+    expect(prisma.postInteraction.findMany).toHaveBeenCalledWith(expect.objectContaining({ where: { type: InteractionType.REPOST } }));
+    expect(res.posts.length).toBe(2);
+    const repostItem = res.posts.find(p => p.repostedBy);
+    expect(repostItem?.repostedBy?.username).toBe('reposter');
+    expect(res.total).toBe(2);
+  });
+});


### PR DESCRIPTION
## Summary
- include repost interactions in weighted feed and expose reposter
- extend feed DTO and PostCard to render `repostedBy`
- add unit test covering repost feed items

## Testing
- `npm test`
- `npx jest src/posts/post.service.spec.ts`


------
https://chatgpt.com/codex/tasks/task_e_689cd6e5a5a88327b77553ea852e9794