### PR TITLE
Add profile header and hide profile icon on profile page

### DIFF
--- a/astrogram/src/components/Navbar/Navbar.tsx
+++ b/astrogram/src/components/Navbar/Navbar.tsx
@@ -1,6 +1,6 @@
 import { Menu, Bell, User, ChevronDown, ChevronUp } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
-import { Link } from 'react-router-dom';
+import { Link, useLocation } from 'react-router-dom';
 import { useAuth } from "../../contexts/AuthContext";
 import { useNotifications } from "../../contexts/NotificationContext";
 
@@ -13,6 +13,8 @@ const Navbar = () => {
   const dropdownRef = useRef<HTMLDivElement>(null);
   const { user } = useAuth();
   const { count } = useNotifications();
+  const location = useLocation();
+  const isProfilePage = location.pathname.startsWith('/profile');
 
 
   useEffect(() => {
@@ -106,17 +108,19 @@ const Navbar = () => {
               )}
             </div>
           </Link>
-          <Link to={user ? '/profile' : '/signup'} className="btn-unstyled" aria-label="Account">
-          {user?.avatarUrl ? (
-            <img
-              src={user.avatarUrl}
-              alt="Your avatar"
-              className="w-8 h-8 rounded-full object-cover"
-            />
-          ) : (
-            <User className="w-6 h-6 m-auto text-gray-400" />
+          {!isProfilePage && (
+            <Link to={user ? '/profile' : '/signup'} className="btn-unstyled" aria-label="Account">
+            {user?.avatarUrl ? (
+              <img
+                src={user.avatarUrl}
+                alt="Your avatar"
+                className="w-8 h-8 rounded-full object-cover"
+              />
+            ) : (
+              <User className="w-6 h-6 m-auto text-gray-400" />
+            )}
+            </Link>
           )}
-          </Link>
         </div>
       </div>
     </nav>

--- a/astrogram/src/pages/ProfilePage.tsx
+++ b/astrogram/src/pages/ProfilePage.tsx
@@ -138,6 +138,25 @@ export default function ProfilePage(): JSX.Element {
 
   return (
     <div className="p-4 max-w-2xl mx-auto text-gray-200">
+      {/* Profile header */}
+      <div className="flex items-center mb-4">
+        {user.avatarUrl ? (
+          <img
+            src={user.avatarUrl}
+            alt="avatar"
+            className="w-16 h-16 rounded-full object-cover"
+          />
+        ) : (
+          <div className="w-16 h-16 rounded-full bg-gray-700" />
+        )}
+        <div className="ml-4">
+          <div className="text-xl font-bold">{user.username}</div>
+          <div className="text-sm text-gray-400">
+            <span className="mr-4"><span className="font-semibold text-white">Trackers</span> 0</span>
+            <span><span className="font-semibold text-white">Tracking</span> 0</span>
+          </div>
+        </div>
+      </div>
       {/* Tabs */}
       <div className="border-b border-gray-700 mb-4 pt-4">
         <nav className="-mb-px flex justify-center space-x-8" aria-label="Profile tabs">


### PR DESCRIPTION
## Summary
- Hide profile icon in navbar when viewing your own profile
- Add header to profile page with avatar, username, and placeholder trackers stats

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689cee362d048327a909439e46a28f26