### PR TITLE
feat: allow users to save posts

### DIFF
--- a/astrogram/src/components/PostCard/PostCard.tsx
+++ b/astrogram/src/components/PostCard/PostCard.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState, useRef } from "react";
 import { useNavigate, Link } from 'react-router-dom';
 import { formatDistanceToNow } from "date-fns";
 import { Star, MessageCircle, Share2, Repeat2, Bookmark, MoreVertical } from "lucide-react";
-import { sharePost, repostPost, apiFetch } from '../../lib/api';
+import { sharePost, repostPost, apiFetch, toggleSave } from '../../lib/api';
 import { useAuth } from "../../contexts/AuthContext";
 
 
@@ -22,6 +22,7 @@ export interface PostCardProps {
   likedByMe?: boolean;
   repostedByMe?: boolean;
   repostedBy?: string;
+  savedByMe?: boolean;
   onDeleted?: (id: string) => void;
 }
 
@@ -40,6 +41,7 @@ const PostCard: React.FC<PostCardProps> = ({
   repostedByMe,
   repostedBy,
   authorId,
+  savedByMe,
   onDeleted
 }) => {
 
@@ -53,7 +55,7 @@ const PostCard: React.FC<PostCardProps> = ({
   const [shareCount, setShareCount] = useState(shares);
   const [reposted, setReposted] = useState(Boolean(repostedByMe));
   const [repostCount, setRepostCount] = useState(reposts);
-  const [saved, setSaved] = useState(false);
+  const [saved, setSaved] = useState(Boolean(savedByMe));
   const [menuOpen, setMenuOpen] = useState(false);
   const menuRef = useRef<HTMLDivElement>(null);
 
@@ -110,6 +112,15 @@ const PostCard: React.FC<PostCardProps> = ({
       } catch (err: unknown) {
         console.error("Failed to repost:", err);
       }
+  };
+
+  const handleSave = async () => {
+    try {
+      const res = await toggleSave(id);
+      setSaved(res.saved);
+    } catch (err) {
+      console.error(err);
+    }
   };
 
   // close menu on outside click
@@ -255,11 +266,10 @@ const PostCard: React.FC<PostCardProps> = ({
             {/* Save */}
             <button
               type="button"
-              onClick={() => setSaved(s => !s)}
+              onClick={handleSave}
               className="btn-unstyled btn-action hover:text-blue-400"
             >
               <Bookmark className="w-5 h-5" fill={saved ? "currentColor" : "none"} />
-              <span>{saved ? 1 : 0}</span>
             </button>
 
             {/* Share */}

--- a/astrogram/src/lib/api.tsx
+++ b/astrogram/src/lib/api.tsx
@@ -221,6 +221,13 @@ export async function interactWithPost(
     return interactWithPost(postId, 'repost');
   }
 
+  export async function toggleSave(
+    postId: string,
+  ): Promise<{ saved: boolean }> {
+    const res = await apiFetch(`/posts/${postId}/save`, { method: 'POST' });
+    return res.json();
+  }
+
 // --------------------------------------------------
 // Comments API helpers
 

--- a/astrogram/src/pages/PostPage.tsx
+++ b/astrogram/src/pages/PostPage.tsx
@@ -53,6 +53,7 @@ const PostPage: React.FC = () => {
           reposts:    data.reposts,
           likedByMe:  data.likedByMe,
           repostedByMe: data.repostedByMe,
+          savedByMe:  data.savedByMe,
           authorId:   data.authorId,
           ...(data.repostedBy ? { repostedBy: data.repostedBy } : {}),
         }

--- a/backend/prisma/migrations/20250715174436_add_saved_posts/migration.sql
+++ b/backend/prisma/migrations/20250715174436_add_saved_posts/migration.sql
@@ -1,0 +1,17 @@
+-- CreateTable
+CREATE TABLE "SavedPost" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "postId" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "SavedPost_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "one_save_per_user_per_post" ON "SavedPost"("postId", "userId");
+
+-- AddForeignKey
+ALTER TABLE "SavedPost" ADD CONSTRAINT "SavedPost_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "SavedPost" ADD CONSTRAINT "SavedPost_postId_fkey" FOREIGN KEY ("postId") REFERENCES "Post"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -36,6 +36,7 @@ model User {
   originalPosts     Post[]            @relation("OriginalAuthor")
   interactions      PostInteraction[]
   commentLikes      CommentLike[]
+  savedPosts        SavedPost[]
   sentNotifications Notification[]    @relation("Actor") // created by this user
   notifications     Notification[] // received by this user
   followedLounges   Lounge[]          @relation("LoungeFollowers")
@@ -60,6 +61,7 @@ model Post {
   originalAuthor User?            @relation("OriginalAuthor", fields: [originalAuthorId], references: [id])
   lounge        Lounge?           @relation(fields: [loungeId], references: [id])
   interactions  PostInteraction[]
+  savedBy       SavedPost[]
   notifications Notification[]
 }
 
@@ -88,6 +90,17 @@ model CommentLike {
   createdAt DateTime @default(now())
 
   @@unique([commentId, userId], name: "one_like_per_user_per_comment")
+}
+
+model SavedPost {
+  id        String   @id @default(uuid())
+  user      User     @relation(fields: [userId], references: [id])
+  userId    String
+  post      Post     @relation(fields: [postId], references: [id])
+  postId    String
+  createdAt DateTime @default(now())
+
+  @@unique([postId, userId], name: "one_save_per_user_per_post")
 }
 
 model PostInteraction {

--- a/backend/src/posts/dto/feed.dto.ts
+++ b/backend/src/posts/dto/feed.dto.ts
@@ -11,6 +11,7 @@ export interface FeedPostDto {
   reposts: number;
   likedByMe: boolean;
   repostedByMe: boolean;
+  savedByMe: boolean;
   repostedBy?: string;
   title?: string;
   imageUrl?: string;

--- a/backend/src/posts/post.controller.ts
+++ b/backend/src/posts/post.controller.ts
@@ -1,184 +1,202 @@
 // src/posts/posts.controller.ts
 import {
-    Controller,
-    Post,
-    Param,
-    Req,
-    UseGuards,
-    Logger,
-    Body,
-    UseInterceptors,
-    UploadedFile,
-    Get,
-    Query,
-    InternalServerErrorException,
-    Delete,
-} from '@nestjs/common'
-import { JwtAuthGuard } from '../auth/jwt-auth.guard'
-import { PostsService } from './post.service'
-import { InteractionType } from '@prisma/client'
-import { CreatePostDto } from './dto/create-post.dto'
-import { FileInterceptor } from '@nestjs/platform-express'
-import { OptionalAuthGuard } from '../auth/jwt-optional.guard'
-import { FeedResponseDto } from './dto/feed.dto'
+  Controller,
+  Post,
+  Param,
+  Req,
+  UseGuards,
+  Logger,
+  Body,
+  UseInterceptors,
+  UploadedFile,
+  Get,
+  Query,
+  InternalServerErrorException,
+  Delete,
+} from '@nestjs/common';
+import { JwtAuthGuard } from '../auth/jwt-auth.guard';
+import { PostsService } from './post.service';
+import { InteractionType } from '@prisma/client';
+import { CreatePostDto } from './dto/create-post.dto';
+import { FileInterceptor } from '@nestjs/platform-express';
+import { OptionalAuthGuard } from '../auth/jwt-optional.guard';
+import { FeedResponseDto } from './dto/feed.dto';
 
 @Controller('api/posts')
 export class PostsController {
-    private readonly logger = new Logger(PostsController.name)
+  private readonly logger = new Logger(PostsController.name);
 
-    constructor(private readonly posts: PostsService) { }
+  constructor(private readonly posts: PostsService) {}
 
-    /**
- * Public feed endpoint, no auth required.
- * Supports ?page=1&limit=20 query params.
- */
-    @UseGuards(OptionalAuthGuard)
-    @Get('feed')
-    async getFeed(
-        @Req() req: any,
-        @Query('page') page = '1',
-        @Query('limit') limit = '20',
-    ): Promise<FeedResponseDto> {
-        const p = parseInt(page, 10) || 1;
-        const l = parseInt(limit, 10) || 20;
-        this.logger.log(`Fetching public feed (page=${p}, limit=${l})`);
+  /**
+   * Public feed endpoint, no auth required.
+   * Supports ?page=1&limit=20 query params.
+   */
+  @UseGuards(OptionalAuthGuard)
+  @Get('feed')
+  async getFeed(
+    @Req() req: any,
+    @Query('page') page = '1',
+    @Query('limit') limit = '20',
+  ): Promise<FeedResponseDto> {
+    const p = parseInt(page, 10) || 1;
+    const l = parseInt(limit, 10) || 20;
+    this.logger.log(`Fetching public feed (page=${p}, limit=${l})`);
 
-        console.log(req.user);
+    console.log(req.user);
 
-        const id = req.user ? req.user.sub : null
+    const id = req.user ? req.user.sub : null;
 
-        try {
-            const feed = await this.posts.getWeightedFeed(id, p, l);
-            this.logger.log(`Feed fetched: ${feed.posts.length} items`);
-            return feed;
-        } catch (err: any) {
-            this.logger.error(`Failed to fetch feed`, err.stack);
-            throw new InternalServerErrorException('Could not fetch feed');
-        }
+    try {
+      const feed = await this.posts.getWeightedFeed(id, p, l);
+      this.logger.log(`Feed fetched: ${feed.posts.length} items`);
+      return feed;
+    } catch (err: any) {
+      this.logger.error(`Failed to fetch feed`, err.stack);
+      throw new InternalServerErrorException('Could not fetch feed');
     }
+  }
 
-    @UseGuards(JwtAuthGuard)
-    @UseInterceptors(
-        FileInterceptor('image', {
-            fileFilter: (_req, file, cb) => {
-                const allowed = ['image/jpeg', 'image/png', 'image/gif']
-                if (allowed.includes(file.mimetype)) cb(null, true)
-                else cb(new Error('Invalid file type'), false)
-            },
-            limits: { fileSize: 5 * 1024 * 1024 }, // optional 5MB limit
-        }),
-    )
-    @Post()
-    async createPost(
-        @Req() req: any,
-        @UploadedFile() file: Express.Multer.File,
-        @Body() dto: CreatePostDto,
-    ) {
-        const userId = req.user.sub as string
-        this.logger.log(`User ${userId} → CREATE POST`)
-        try {
-            const post = await this.posts.create(userId, dto, file)
-            this.logger.log(`CREATE POST success: ${post.id}`)
-            return post
-        } catch (err: any) {
-            this.logger.error(
-                `CREATE POST failed for user ${userId}: ${err.message}`,
-                err.stack,
-            )
-            throw err
-        }
+  @UseGuards(JwtAuthGuard)
+  @UseInterceptors(
+    FileInterceptor('image', {
+      fileFilter: (_req, file, cb) => {
+        const allowed = ['image/jpeg', 'image/png', 'image/gif'];
+        if (allowed.includes(file.mimetype)) cb(null, true);
+        else cb(new Error('Invalid file type'), false);
+      },
+      limits: { fileSize: 5 * 1024 * 1024 }, // optional 5MB limit
+    }),
+  )
+  @Post()
+  async createPost(
+    @Req() req: any,
+    @UploadedFile() file: Express.Multer.File,
+    @Body() dto: CreatePostDto,
+  ) {
+    const userId = req.user.sub as string;
+    this.logger.log(`User ${userId} → CREATE POST`);
+    try {
+      const post = await this.posts.create(userId, dto, file);
+      this.logger.log(`CREATE POST success: ${post.id}`);
+      return post;
+    } catch (err: any) {
+      this.logger.error(
+        `CREATE POST failed for user ${userId}: ${err.message}`,
+        err.stack,
+      );
+      throw err;
     }
+  }
 
-    @UseGuards(JwtAuthGuard)
-    @Post(':id/share')
-    async sharePost(@Req() req: any, @Param('id') postId: string) {
-        const userId = req.user.sub as string
-        this.logger.log(`User ${userId} → SHARE → post ${postId}`)
+  @UseGuards(JwtAuthGuard)
+  @Post(':id/share')
+  async sharePost(@Req() req: any, @Param('id') postId: string) {
+    const userId = req.user.sub as string;
+    this.logger.log(`User ${userId} → SHARE → post ${postId}`);
 
-        try {
-            const result = await this.posts.interact(
-                userId,
-                postId,
-                InteractionType.SHARE,
-            )
-            this.logger.log(
-                `SHARE successful for post ${postId}, new shares = ${result.count}`,
-            )
-            return result
-        } catch (err: any) {
-            this.logger.error(
-                `SHARE failed for post ${postId}: ${err.message}`,
-                err.stack,
-            )
-            throw err
-        }
+    try {
+      const result = await this.posts.interact(
+        userId,
+        postId,
+        InteractionType.SHARE,
+      );
+      this.logger.log(
+        `SHARE successful for post ${postId}, new shares = ${result.count}`,
+      );
+      return result;
+    } catch (err: any) {
+      this.logger.error(
+        `SHARE failed for post ${postId}: ${err.message}`,
+        err.stack,
+      );
+      throw err;
     }
+  }
 
-    @UseGuards(JwtAuthGuard)
-    @Post(':id/repost')
-    async repostPost(@Req() req: any, @Param('id') postId: string) {
-        const userId = req.user.sub as string
-        this.logger.log(`User ${userId} → REPOST → post ${postId}`)
+  @UseGuards(JwtAuthGuard)
+  @Post(':id/repost')
+  async repostPost(@Req() req: any, @Param('id') postId: string) {
+    const userId = req.user.sub as string;
+    this.logger.log(`User ${userId} → REPOST → post ${postId}`);
 
-        try {
-            const result = await this.posts.interact(
-                userId,
-                postId,
-                InteractionType.REPOST,
-            )
-            this.logger.log(
-                `REPOST successful for post ${postId}, new reposts = ${result.count}`,
-            )
-            return result
-        } catch (err: any) {
-            this.logger.error(
-                `REPOST failed for post ${postId}: ${err.message}`,
-                err.stack,
-            )
-            throw err
-        }
+    try {
+      const result = await this.posts.interact(
+        userId,
+        postId,
+        InteractionType.REPOST,
+      );
+      this.logger.log(
+        `REPOST successful for post ${postId}, new reposts = ${result.count}`,
+      );
+      return result;
+    } catch (err: any) {
+      this.logger.error(
+        `REPOST failed for post ${postId}: ${err.message}`,
+        err.stack,
+      );
+      throw err;
     }
+  }
 
-    @UseGuards(JwtAuthGuard)
-    @Post(':id/like')
-    async toggleLikePost(@Req() req: any, @Param('id') postId: string) {
-        const userId = req.user.sub as string;
-        this.logger.log(`User ${userId} → TOGGLE LIKE → post ${postId}`);
-        try {
-            const { liked, count } = await this.posts.toggleLike(userId, postId);
-            this.logger.log(`TOGGLE LIKE: liked=${liked}, total=${count}`);
-            return { liked, count };
-        } catch (err: any) {
-            this.logger.error(`TOGGLE LIKE failed for ${postId}: ${err.message}`, err.stack);
-            throw err;
-        }
+  @UseGuards(JwtAuthGuard)
+  @Post(':id/like')
+  async toggleLikePost(@Req() req: any, @Param('id') postId: string) {
+    const userId = req.user.sub as string;
+    this.logger.log(`User ${userId} → TOGGLE LIKE → post ${postId}`);
+    try {
+      const { liked, count } = await this.posts.toggleLike(userId, postId);
+      this.logger.log(`TOGGLE LIKE: liked=${liked}, total=${count}`);
+      return { liked, count };
+    } catch (err: any) {
+      this.logger.error(
+        `TOGGLE LIKE failed for ${postId}: ${err.message}`,
+        err.stack,
+      );
+      throw err;
     }
+  }
 
-    @Get(':id')
-    @UseGuards(OptionalAuthGuard)  // if you want only logged‑in users, otherwise drop this
-    async getPost(
-        @Req() req: any,
-        @Param('id') postId: string
-    ) {
-        const userId = req.user?.sub as string ? req.user.sub : null;
-        this.logger.log(`User ${userId} → FETCH POST → ${postId}`);
-        try {
-            const post = await this.posts.getPostById(postId, userId);
-            this.logger.log(`FETCH POST success: ${postId}`);
-            return post;
-        } catch (err) {
-            this.logger.error(`FETCH POST failed for ${postId}: ${err.message}`);
-            throw err;
-        }
+  @UseGuards(JwtAuthGuard)
+  @Post(':id/save')
+  async toggleSavePost(@Req() req: any, @Param('id') postId: string) {
+    const userId = req.user.sub as string;
+    this.logger.log(`User ${userId} → TOGGLE SAVE → post ${postId}`);
+    try {
+      const { saved } = await this.posts.toggleSave(userId, postId);
+      this.logger.log(`TOGGLE SAVE: saved=${saved}`);
+      return { saved };
+    } catch (err: any) {
+      this.logger.error(
+        `TOGGLE SAVE failed for ${postId}: ${err.message}`,
+        err.stack,
+      );
+      throw err;
     }
+  }
 
-    @UseGuards(JwtAuthGuard)
-    @Delete('delete/:id')
-    async deletePost(
-        @Req() req: { user: { sub: string } },
-        @Param('id') postId: string
-    ) {
-        await this.posts.deletePost(req.user.sub, postId);
-        return { success: true };
+  @Get(':id')
+  @UseGuards(OptionalAuthGuard) // if you want only logged‑in users, otherwise drop this
+  async getPost(@Req() req: any, @Param('id') postId: string) {
+    const userId = (req.user?.sub as string) ? req.user.sub : null;
+    this.logger.log(`User ${userId} → FETCH POST → ${postId}`);
+    try {
+      const post = await this.posts.getPostById(postId, userId);
+      this.logger.log(`FETCH POST success: ${postId}`);
+      return post;
+    } catch (err) {
+      this.logger.error(`FETCH POST failed for ${postId}: ${err.message}`);
+      throw err;
     }
+  }
+
+  @UseGuards(JwtAuthGuard)
+  @Delete('delete/:id')
+  async deletePost(
+    @Req() req: { user: { sub: string } },
+    @Param('id') postId: string,
+  ) {
+    await this.posts.deletePost(req.user.sub, postId);
+    return { success: true };
+  }
 }

--- a/backend/src/users/users.service.ts
+++ b/backend/src/users/users.service.ts
@@ -138,6 +138,7 @@ export class UsersService {
       comments: p._count.comments,
       shares: p.shares,
       likedByMe: false,
+      savedByMe: false,
       ...(p.originalAuthorId && p.originalAuthorId !== p.authorId
         ? { repostedBy: user?.username || '' }
         : {}),
@@ -216,6 +217,7 @@ export class UsersService {
       comments: p._count.comments,
       shares: p.shares,
       likedByMe: false,
+      savedByMe: false,
       ...(p.originalAuthorId && p.originalAuthorId !== p.authorId
         ? { repostedBy: user.username || '' }
         : {}),


### PR DESCRIPTION
## Summary
- add SavedPost model and migration
- expose save/unsave API and surface saved state in feeds
- wire up frontend to toggle saves on posts

## Testing
- `npm test`
- `npm run lint` *(fails: unsafe any usage in existing files)*
- `npm --prefix astrogram run lint`


------
https://chatgpt.com/codex/tasks/task_e_689d01d6af988327b044ddc971232051