### PR TITLE
Rename brand to AstroLounge

### DIFF
--- a/astrogram/index.html
+++ b/astrogram/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Collimate</title>
+    <title>AstroLounge</title>
   </head>
   <body>
     <div id="root"></div>

--- a/astrogram/src/components/Navbar/Navbar.tsx
+++ b/astrogram/src/components/Navbar/Navbar.tsx
@@ -65,7 +65,7 @@ const Navbar = () => {
             />
           </button>
 
-          {/* ColliMate Dropdown */}
+          {/* AstroLounge Dropdown */}
           <div className="relative" ref={dropdownRef}>
             <button
               className="btn-unstyled flex items-center gap-1"
@@ -74,7 +74,7 @@ const Navbar = () => {
               aria-haspopup="true"
               aria-expanded={dropdownOpen}
             >
-              <span className="text-lg font-semibold leading-none">ColliMate</span>
+              <span className="text-lg font-semibold leading-none">AstroLounge</span>
               {/* <ChevronDown className="w-4 h-4 align-middle" /> */}
             </button>
 


### PR DESCRIPTION
## Summary
- replace Collimate with AstroLounge in tab title
- update navbar branding to AstroLounge

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689d06b112ec8327a98644e46fd8d3ef