### PR TITLE
fix: offset lounges content below navbar

### DIFF
--- a/astrogram/src/pages/LoungesPage.tsx
+++ b/astrogram/src/pages/LoungesPage.tsx
@@ -28,7 +28,7 @@ const LoungesPage: React.FC = () => {
     .sort((a, b) => a.name.localeCompare(b.name));
 
   return (
-    <div>
+    <div className="mt-8">
       <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
         {sortedLounges.map((lounge) => {
           const isFollowed = user?.followedLounges?.includes(lounge.id) ?? false;


### PR DESCRIPTION
## Summary
- ensure Lounges page content starts below the fixed navbar

## Testing
- `npm test` (fails: Missing script)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689d5ea923ec83278f8448420d2a68b8