### PR TITLE
feat: raise multer file limit to 10MB

### DIFF
--- a/backend/src/lounges/lounges.controller.ts
+++ b/backend/src/lounges/lounges.controller.ts
@@ -50,7 +50,7 @@ export class LoungesController {
           if (allowed.includes(file.mimetype)) cb(null, true);
           else cb(new Error('Invalid file type'), false);
         },
-        limits: { fileSize: 5 * 1024 * 1024 },
+        limits: { fileSize: 10 * 1024 * 1024 },
       },
     ),
   )
@@ -98,7 +98,7 @@ export class LoungesController {
         if (allowed.includes(file.mimetype)) cb(null, true);
         else cb(new Error('Invalid file type'), false);
       },
-      limits: { fileSize: 5 * 1024 * 1024 },
+      limits: { fileSize: 10 * 1024 * 1024 },
     }),
   )
   async createLoungePost(
@@ -155,7 +155,7 @@ export class LoungesController {
           if (allowed.includes(file.mimetype)) cb(null, true);
           else cb(new Error('Invalid file type'), false);
         },
-        limits: { fileSize: 5 * 1024 * 1024 },
+        limits: { fileSize: 10 * 1024 * 1024 },
       },
     ),
   )

--- a/backend/src/posts/post.controller.ts
+++ b/backend/src/posts/post.controller.ts
@@ -65,7 +65,7 @@ export class PostsController {
                 if (allowed.includes(file.mimetype)) cb(null, true)
                 else cb(new Error('Invalid file type'), false)
             },
-            limits: { fileSize: 5 * 1024 * 1024 }, // optional 5MB limit
+            limits: { fileSize: 10 * 1024 * 1024 }, // optional 10MB limit
         }),
     )
     @Post()

--- a/backend/src/users/users.controller.ts
+++ b/backend/src/users/users.controller.ts
@@ -68,7 +68,7 @@ export class UsersController {
         if (allowed.includes(file.mimetype)) cb(null, true);
         else cb(new Error('Invalid file type'), false);
       },
-      limits: { fileSize: 5 * 1024 * 1024 }, // optional 5MB limit
+      limits: { fileSize: 10 * 1024 * 1024 }, // optional 10MB limit
     }),
   )
   async updateProfile(


### PR DESCRIPTION
## Summary
- allow up to 10MB uploads in posts, users and lounges controllers

## Testing
- `npm test`
- `npm run lint` *(fails: many existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_689e131f60308327b3deca59afbbf6bb