### PR TITLE
Persist user snapshot for auth rehydration

### DIFF
--- a/astrogram/src/contexts/AuthContext.tsx
+++ b/astrogram/src/contexts/AuthContext.tsx
@@ -37,23 +37,48 @@ export const AuthProvider: React.FC<{ children: ReactNode }> = ({ children }) =>
   const [user, setUser]       = useState<User | null>(null);
   const [loading, setLoading] = useState(true);
 
-  // on mount, rehydrate access token + fetch current user
+  // on mount, rehydrate access token + user snapshot then validate
   useEffect(() => {
-    const saved = localStorage.getItem("ACCESS_TOKEN");
-    if (saved) {
-      setAccessToken(saved);
-      apiFetch("/users/me")
-        .then((res) => {
+    const savedToken = localStorage.getItem("ACCESS_TOKEN");
+    const savedUser = localStorage.getItem("USER_SNAPSHOT");
+    if (savedToken) {
+      setAccessToken(savedToken);
+      if (savedUser) {
+        try {
+          setUser(JSON.parse(savedUser));
+        } catch {
+          localStorage.removeItem("USER_SNAPSHOT");
+        }
+      }
+      (async () => {
+        try {
+          const res = await apiFetch("/users/me");
           if (!res.ok) throw new Error("Not authenticated");
-          return res.json();
-        })
-        .then(setUser)
-        .catch(() => {
-          setUser(null);
-          setAccessToken("");
-          localStorage.removeItem("ACCESS_TOKEN");
-        })
-        .finally(() => setLoading(false));
+          const me = await res.json();
+          setUser(me);
+          localStorage.setItem("USER_SNAPSHOT", JSON.stringify(me));
+        } catch {
+          try {
+            const refreshRes = await apiFetch("/auth/refresh", { method: "POST" });
+            if (!refreshRes.ok) throw new Error("Refresh failed");
+            const { accessToken: newToken } = await refreshRes.json();
+            setAccessToken(newToken);
+            localStorage.setItem("ACCESS_TOKEN", newToken);
+            const userRes = await apiFetch("/users/me");
+            if (!userRes.ok) throw new Error("Not authenticated");
+            const me = await userRes.json();
+            setUser(me);
+            localStorage.setItem("USER_SNAPSHOT", JSON.stringify(me));
+          } catch {
+            setUser(null);
+            setAccessToken("");
+            localStorage.removeItem("ACCESS_TOKEN");
+            localStorage.removeItem("USER_SNAPSHOT");
+          }
+        } finally {
+          setLoading(false);
+        }
+      })();
     } else {
       setLoading(false);
     }
@@ -76,6 +101,7 @@ export const AuthProvider: React.FC<{ children: ReactNode }> = ({ children }) =>
     }
     const me: User = await res.json();
     setUser(me);
+    localStorage.setItem("USER_SNAPSHOT", JSON.stringify(me));
     setLoading(false);
     return me;
   };
@@ -85,6 +111,7 @@ export const AuthProvider: React.FC<{ children: ReactNode }> = ({ children }) =>
     setUser(null);
     setAccessToken("");
     localStorage.removeItem("ACCESS_TOKEN");
+    localStorage.removeItem("USER_SNAPSHOT");
     // optionally call your backend /logout endpoint to clear the refresh cookie
   }, []);
 
@@ -102,7 +129,9 @@ export const AuthProvider: React.FC<{ children: ReactNode }> = ({ children }) =>
         const followedLounges = follow
           ? [...current, loungeId]
           : current.filter((id) => id !== loungeId);
-        return { ...prev, followedLounges };
+        const updated = { ...prev, followedLounges };
+        localStorage.setItem("USER_SNAPSHOT", JSON.stringify(updated));
+        return updated;
       });
     } catch {
       // silently ignore for now


### PR DESCRIPTION
## Summary
- Rehydrate auth state from local storage and refresh token before clearing credentials
- Persist lightweight user profile on login, logout, and lounge follow updates

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689e31d6378c8327b3eee65b3d5e0c55