### PR TITLE
Return user lounge follows and show lounge follower counts

### DIFF
--- a/astrogram/src/data/lounges.ts
+++ b/astrogram/src/data/lounges.ts
@@ -3,7 +3,7 @@ export interface LoungeInfo {
   banner: string;
   icon: string;
   threads: number;
-  views: number;
+  followers: number;
   lastPostAt: string;
 }
 
@@ -13,7 +13,7 @@ export const lounges: Record<string, LoungeInfo> = {
     banner: "https://picsum.photos/seed/astro-banner/1200/300",
     icon: "https://picsum.photos/seed/astro-icon/200",
     threads: 42,
-    views: 1234,
+    followers: 1234,
     lastPostAt: "2025-07-01T12:00:00Z",
   },
   lunisolar: {
@@ -21,7 +21,7 @@ export const lounges: Record<string, LoungeInfo> = {
     banner: "https://picsum.photos/seed/lunisolar-banner/1200/300",
     icon: "https://picsum.photos/seed/lunisolar-icon/200",
     threads: 37,
-    views: 980,
+    followers: 980,
     lastPostAt: "2025-07-02T09:30:00Z",
   },
   planetary: {
@@ -29,7 +29,7 @@ export const lounges: Record<string, LoungeInfo> = {
     banner: "https://picsum.photos/seed/planetary-banner/1200/300",
     icon: "https://picsum.photos/seed/planetary-icon/200",
     threads: 58,
-    views: 1500,
+    followers: 1500,
     lastPostAt: "2025-07-03T15:45:00Z",
   },
   dso: {
@@ -37,7 +37,7 @@ export const lounges: Record<string, LoungeInfo> = {
     banner: "https://picsum.photos/seed/dso-banner/1200/300",
     icon: "https://picsum.photos/seed/dso-icon/200",
     threads: 22,
-    views: 760,
+    followers: 760,
     lastPostAt: "2025-06-30T18:20:00Z",
   },
   equipment: {
@@ -45,7 +45,7 @@ export const lounges: Record<string, LoungeInfo> = {
     banner: "https://picsum.photos/seed/equipment-banner/1200/300",
     icon: "https://picsum.photos/seed/equipment-icon/200",
     threads: 16,
-    views: 540,
+    followers: 540,
     lastPostAt: "2025-07-01T08:10:00Z",
   },
   astroadjacent: {
@@ -53,7 +53,7 @@ export const lounges: Record<string, LoungeInfo> = {
     banner: "https://picsum.photos/seed/astroadjacent-banner/1200/300",
     icon: "https://picsum.photos/seed/astroadjacent-icon/200",
     threads: 29,
-    views: 1120,
+    followers: 1120,
     lastPostAt: "2025-07-02T20:15:00Z",
   },
   askastro: {
@@ -61,7 +61,7 @@ export const lounges: Record<string, LoungeInfo> = {
     banner: "https://picsum.photos/seed/askastro-banner/1200/300",
     icon: "https://picsum.photos/seed/askastro-icon/200",
     threads: 11,
-    views: 430,
+    followers: 430,
     lastPostAt: "2025-06-29T14:05:00Z",
   },
 };

--- a/astrogram/src/pages/LoungesPage.tsx
+++ b/astrogram/src/pages/LoungesPage.tsx
@@ -9,7 +9,7 @@ interface LoungeInfo {
   bannerUrl: string;
   profileUrl: string;
   threads?: number;
-  views?: number;
+  followers?: number;
   lastPostAt?: string | null;
 }
 
@@ -55,7 +55,7 @@ const LoungesPage: React.FC = () => {
                   <div className="text-lg font-semibold">{lounge.name}</div>
                   <div className="text-sm text-neutral-400 flex items-center gap-2">
                     <span>
-                      {lounge.threads ?? 0} Threads · {lounge.views ?? 0} Views
+                      {lounge.threads ?? 0} Threads · {lounge.followers ?? 0} Trackers
                     </span>
                     {user && (
                       <button

--- a/backend/src/lounges/lounges.service.ts
+++ b/backend/src/lounges/lounges.service.ts
@@ -69,7 +69,7 @@ export class LoungesService {
     this.logger.log('Fetching all lounges');
     const lounges = await this.prisma.lounge.findMany({
       include: {
-        _count: { select: { posts: true } },
+        _count: { select: { posts: true, followers: true } },
         posts: {
           select: { createdAt: true },
           orderBy: { createdAt: 'desc' },
@@ -86,7 +86,7 @@ export class LoungesService {
       bannerUrl: l.bannerUrl,
       profileUrl: l.profileUrl,
       threads: l._count.posts,
-      views: 0,
+      followers: l._count.followers,
       lastPostAt: l.posts[0]?.createdAt ?? null,
     }));
   }
@@ -96,7 +96,7 @@ export class LoungesService {
     const lounge = await this.prisma.lounge.findUnique({
       where: { name },
       include: {
-        _count: { select: { posts: true } },
+        _count: { select: { posts: true, followers: true } },
         posts: {
           select: { createdAt: true },
           orderBy: { createdAt: 'desc' },
@@ -118,7 +118,7 @@ export class LoungesService {
       bannerUrl: lounge.bannerUrl,
       profileUrl: lounge.profileUrl,
       threads: lounge._count.posts,
-      views: 0,
+      followers: lounge._count.followers,
       lastPostAt: lounge.posts[0]?.createdAt ?? null,
     };
   }

--- a/backend/src/users/users.controller.ts
+++ b/backend/src/users/users.controller.ts
@@ -40,14 +40,10 @@ export class UsersController {
       this.logger.log(
         `Returning user: id=${user.id}, username=${user.username}, profileComplete=${user.profileComplete}`,
       );
-
-      return {
-        id: user.id,
-        username: user.username,
-        avatarUrl: user.avatarUrl,
-        profileComplete: user.profileComplete,
-        role: user.role,
-      };
+      // Include followed lounge IDs so the client knows which lounges
+      // the user is already tracking without having to fetch them
+      // separately.
+      return user;
     } catch (error: unknown) {
       const message = error instanceof Error ? error.message : String(error);
       const stack = error instanceof Error ? error.stack : undefined;


### PR DESCRIPTION
## Summary
- include followed lounge ids in `/api/users/me` response
- track lounge follower counts in service and replace card views with tracker counts

## Testing
- `npm test` (backend)
- `npm run lint` (backend) *(fails: 143 problems)*
- `npm test` (astrogram) *(missing script)*
- `npm run lint` (astrogram)


------
https://chatgpt.com/codex/tasks/task_e_689f958f9f288327843c6819bd3a34ff