### PR TITLE
feat: sort lounges by recent activity

### DIFF
--- a/astrogram/src/pages/LoungePage.tsx
+++ b/astrogram/src/pages/LoungePage.tsx
@@ -183,7 +183,13 @@ const LoungePage: React.FC = () => {
                     alt={`${post.username} avatar`}
                     className="w-8 h-8 rounded-full object-cover mr-2"
                   />
-                  <span className="font-medium">{post.username}</span>
+                  <Link
+                    to={`/users/${post.username}/posts`}
+                    onClick={(e) => e.stopPropagation()}
+                    className="font-medium text-teal-400 hover:underline"
+                  >
+                    @{post.username}
+                  </Link>
                   <span className="ml-2 text-sm text-gray-500">
                     {formatDistanceToNow(new Date(post.timestamp), { addSuffix: true })}
                   </span>

--- a/astrogram/src/pages/LoungePage.tsx
+++ b/astrogram/src/pages/LoungePage.tsx
@@ -186,7 +186,7 @@ const LoungePage: React.FC = () => {
                   <Link
                     to={`/users/${post.username}/posts`}
                     onClick={(e) => e.stopPropagation()}
-                    className="font-medium text-teal-400 hover:underline"
+                    className="font-semibold text-teal-400 text-sm hover:underline"
                   >
                     @{post.username}
                   </Link>

--- a/astrogram/src/pages/LoungePostDetailPage.tsx
+++ b/astrogram/src/pages/LoungePostDetailPage.tsx
@@ -76,7 +76,7 @@ const LoungePostDetailPage: React.FC = () => {
         <div>
           <Link
             to={`/users/${post.username}/posts`}
-            className="font-medium text-teal-400 hover:underline"
+            className="font-semibold text-teal-400 text-sm hover:underline"
           >
             @{post.username}
           </Link>

--- a/astrogram/src/pages/LoungePostDetailPage.tsx
+++ b/astrogram/src/pages/LoungePostDetailPage.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState, useRef } from "react";
-import { useParams, useNavigate } from "react-router-dom";
+import { useParams, useNavigate, Link } from "react-router-dom";
 import { formatDistanceToNow } from "date-fns";
 import { apiFetch } from "../lib/api";
 import Comments from "../components/Comments/Comments";
@@ -74,7 +74,12 @@ const LoungePostDetailPage: React.FC = () => {
           className="w-10 h-10 rounded-full object-cover mr-3"
         />
         <div>
-          <div className="font-medium">{post.username}</div>
+          <Link
+            to={`/users/${post.username}/posts`}
+            className="font-medium text-teal-400 hover:underline"
+          >
+            @{post.username}
+          </Link>
           <div className="text-sm text-gray-500">
             {formatDistanceToNow(new Date(post.timestamp), { addSuffix: true })}
           </div>

--- a/astrogram/src/pages/LoungesPage.tsx
+++ b/astrogram/src/pages/LoungesPage.tsx
@@ -16,14 +16,6 @@ interface LoungeInfo {
 const LoungesPage: React.FC = () => {
   const { user, updateFollowedLounge } = useAuth();
   const [lounges, setLounges] = useState<LoungeInfo[]>([]);
-  const pinnedLounges = [
-    "LuniSolar",
-    "Planetary",
-    "DSO",
-    "Equipment",
-    "AstroAdjacent",
-    "AskAstro",
-  ];
 
   useEffect(() => {
     fetchLounges<LoungeInfo>()
@@ -34,20 +26,13 @@ const LoungesPage: React.FC = () => {
       .catch(() => {});
   }, []);
 
-  const sortedLounges = (() => {
-    const pinned: LoungeInfo[] = [];
-    const others: LoungeInfo[] = [];
-    lounges.forEach((lounge) => {
-      if (pinnedLounges.includes(lounge.name)) pinned.push(lounge);
-      else others.push(lounge);
-    });
-    const sortByLastPost = (a: LoungeInfo, b: LoungeInfo) => {
-      const aTime = a.lastPostAt ? new Date(a.lastPostAt).getTime() : 0;
-      const bTime = b.lastPostAt ? new Date(b.lastPostAt).getTime() : 0;
-      return bTime - aTime;
-    };
-    return [...pinned.sort(sortByLastPost), ...others.sort(sortByLastPost)];
-  })();
+  const sortByLastPost = (a: LoungeInfo, b: LoungeInfo) => {
+    const aTime = a.lastPostAt ? new Date(a.lastPostAt).getTime() : 0;
+    const bTime = b.lastPostAt ? new Date(b.lastPostAt).getTime() : 0;
+    return bTime - aTime;
+  };
+
+  const sortedLounges = [...lounges].sort(sortByLastPost);
 
   return (
     <div className="mt-8">

--- a/astrogram/src/pages/LoungesPage.tsx
+++ b/astrogram/src/pages/LoungesPage.tsx
@@ -16,6 +16,14 @@ interface LoungeInfo {
 const LoungesPage: React.FC = () => {
   const { user, updateFollowedLounge } = useAuth();
   const [lounges, setLounges] = useState<LoungeInfo[]>([]);
+  const pinnedLounges = [
+    "LuniSolar",
+    "Planetary",
+    "DSO",
+    "Equipment",
+    "AstroAdjacent",
+    "AskAstro",
+  ];
 
   useEffect(() => {
     fetchLounges<LoungeInfo>()
@@ -23,9 +31,20 @@ const LoungesPage: React.FC = () => {
       .catch(() => {});
   }, []);
 
-  const sortedLounges = lounges
-    .slice()
-    .sort((a, b) => a.name.localeCompare(b.name));
+  const sortedLounges = (() => {
+    const pinned: LoungeInfo[] = [];
+    const others: LoungeInfo[] = [];
+    lounges.forEach((lounge) => {
+      if (pinnedLounges.includes(lounge.name)) pinned.push(lounge);
+      else others.push(lounge);
+    });
+    const sortByLastPost = (a: LoungeInfo, b: LoungeInfo) => {
+      const aTime = a.lastPostAt ? new Date(a.lastPostAt).getTime() : 0;
+      const bTime = b.lastPostAt ? new Date(b.lastPostAt).getTime() : 0;
+      return bTime - aTime;
+    };
+    return [...pinned.sort(sortByLastPost), ...others.sort(sortByLastPost)];
+  })();
 
   return (
     <div className="mt-8">

--- a/astrogram/src/pages/LoungesPage.tsx
+++ b/astrogram/src/pages/LoungesPage.tsx
@@ -27,7 +27,10 @@ const LoungesPage: React.FC = () => {
 
   useEffect(() => {
     fetchLounges<LoungeInfo>()
-      .then((data) => setLounges(data))
+      .then((data) => {
+        console.log("Fetched lounges:", data);
+        setLounges(data);
+      })
       .catch(() => {});
   }, []);
 


### PR DESCRIPTION
## Summary
- sort lounges by their latest post time
- pin common lounges near the top of the list

## Testing
- `cd backend && npm test`
- `cd astrogram && npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689f9947d97c8327bc08c08e72594ecc