### PR TITLE
Prevent concurrent post submissions

### DIFF
--- a/astrogram/src/components/UploadForm/UploadForm.tsx
+++ b/astrogram/src/components/UploadForm/UploadForm.tsx
@@ -38,6 +38,7 @@ const UploadForm: React.FC = () => {
 
   const handleSubmit = async (e: FormEvent) => {
     e.preventDefault()
+    if (loading) return
     setError(null)
     if (!caption.trim()) {
       setCaptionError('Caption is required')

--- a/astrogram/src/pages/LoungePostPage.tsx
+++ b/astrogram/src/pages/LoungePostPage.tsx
@@ -55,6 +55,7 @@ const LoungePostPage: React.FC = () => {
 
   const handleSubmit = async (e: FormEvent) => {
     e.preventDefault();
+    if (loading) return;
     setError(null);
     const plain = body.replace(/<[^>]*>/g, "").trim();
     if (!title.trim() || !plain) {


### PR DESCRIPTION
## Summary
- Guard post submission handlers against multiple concurrent requests

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a6016b0bf8832798fe936419f9218f