### PR TITLE
style: use white text for lounge post button

### DIFF
--- a/astrogram/src/pages/LoungePage.tsx
+++ b/astrogram/src/pages/LoungePage.tsx
@@ -121,7 +121,7 @@ const LoungePage: React.FC = () => {
           {user && (
             <Link
               to={`/lounge/${encodeURIComponent(lounge.name)}/post`}
-              className="px-4 py-2 rounded bg-purple-600 text-white hover:bg-purple-700 transition-colors"
+              className="px-4 py-2 rounded text-white hover:text-gray-200 transition-colors"
             >
               Post
             </Link>


### PR DESCRIPTION
## Summary
- restyle lounge page's Post button to use standard white text instead of link blue

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a60a5303f883279f72e675328e1b68