### PR TITLE
feat: add user follow relations

### DIFF
--- a/astrogram/src/hooks/useAuth.ts
+++ b/astrogram/src/hooks/useAuth.ts
@@ -17,6 +17,9 @@ export function useAuth() {
       updateFollowedLounge: async () => {
         throw new Error('AuthProvider is missing');
       },
+      updateFollowingUser: async () => {
+        throw new Error('AuthProvider is missing');
+      },
     };
   }
   return ctx;

--- a/astrogram/src/lib/api.tsx
+++ b/astrogram/src/lib/api.tsx
@@ -299,9 +299,21 @@ export async function fetchMyComments<T = unknown>(): Promise<T[]> {
   return res.json();
 }
 
-export async function fetchUser(username: string) {
+export async function fetchUser<T = unknown>(username: string): Promise<T> {
   const res = await apiFetch(`/users/${username}`);
   return res.json();
+}
+
+export async function followUser(username: string) {
+  await apiFetch(`/users/${encodeURIComponent(username)}/follow`, {
+    method: 'POST',
+  });
+}
+
+export async function unfollowUser(username: string) {
+  await apiFetch(`/users/${encodeURIComponent(username)}/follow`, {
+    method: 'DELETE',
+  });
 }
 
 export async function fetchUserPosts<T = unknown>(username: string): Promise<T[]> {

--- a/astrogram/src/pages/ProfilePage.tsx
+++ b/astrogram/src/pages/ProfilePage.tsx
@@ -152,8 +152,8 @@ export default function ProfilePage(): JSX.Element {
         <div className="ml-4">
           <div className="text-xl font-bold">{user.username}</div>
           <div className="text-sm text-gray-400">
-            <span className="mr-4"><span className="font-semibold text-white">Trackers</span> 0</span>
-            <span><span className="font-semibold text-white">Tracking</span> 0</span>
+            <span className="mr-4"><span className="font-semibold text-white">Trackers</span> {user.followers?.length ?? 0}</span>
+            <span><span className="font-semibold text-white">Tracking</span> {user.following?.length ?? 0}</span>
           </div>
         </div>
       </div>

--- a/backend/prisma/migrations/20250715174436_add_user_follows/migration.sql
+++ b/backend/prisma/migrations/20250715174436_add_user_follows/migration.sql
@@ -1,0 +1,13 @@
+-- CreateTable
+CREATE TABLE "_UserFollows" (
+    "A" TEXT NOT NULL,
+    "B" TEXT NOT NULL,
+    CONSTRAINT "_UserFollows_AB_pkey" PRIMARY KEY ("A","B")
+);
+
+-- CreateIndex
+CREATE INDEX "_UserFollows_B_index" ON "_UserFollows"("B");
+
+-- AddForeignKey
+ALTER TABLE "_UserFollows" ADD CONSTRAINT "_UserFollows_A_fkey" FOREIGN KEY ("A") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "_UserFollows" ADD CONSTRAINT "_UserFollows_B_fkey" FOREIGN KEY ("B") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -39,44 +39,46 @@ model User {
   sentNotifications Notification[]    @relation("Actor") // created by this user
   notifications     Notification[] // received by this user
   followedLounges   Lounge[]          @relation("LoungeFollowers")
+  followers         User[]            @relation("UserFollows")
+  following         User[]            @relation("UserFollows")
 
   @@unique([provider, providerId], name: "provider_providerId")
 }
 
 model Post {
-  id            String            @id @default(uuid())
-  authorId      String
+  id               String            @id @default(uuid())
+  authorId         String
   originalAuthorId String?
-  title         String
-  body          String
-  imageUrl      String?
-  loungeId      String?
-  likes         Int               @default(0)
-  shares        Int               @default(0)
-  reposts       Int               @default(0)
-  createdAt     DateTime          @default(now())
-  comments      Comment[]         @relation("PostComments")
-  author        User              @relation("UserPosts", fields: [authorId], references: [id])
-  originalAuthor User?            @relation("OriginalAuthor", fields: [originalAuthorId], references: [id])
-  lounge        Lounge?           @relation(fields: [loungeId], references: [id])
-  interactions  PostInteraction[]
-  notifications Notification[]
+  title            String
+  body             String
+  imageUrl         String?
+  loungeId         String?
+  likes            Int               @default(0)
+  shares           Int               @default(0)
+  reposts          Int               @default(0)
+  createdAt        DateTime          @default(now())
+  comments         Comment[]         @relation("PostComments")
+  author           User              @relation("UserPosts", fields: [authorId], references: [id])
+  originalAuthor   User?             @relation("OriginalAuthor", fields: [originalAuthorId], references: [id])
+  lounge           Lounge?           @relation(fields: [loungeId], references: [id])
+  interactions     PostInteraction[]
+  notifications    Notification[]
 }
 
 model Comment {
-  id        String   @id @default(uuid())
-  postId    String
-  authorId  String
-  text      String
-  likes     Int      @default(0)
-  createdAt DateTime @default(now())
-  parentId  String?
-  author    User     @relation("UserComments", fields: [authorId], references: [id])
-  post      Post     @relation("PostComments", fields: [postId], references: [id])
-  parent    Comment? @relation("CommentReplies", fields: [parentId], references: [id])
-  replies   Comment[] @relation("CommentReplies")
-  likedBy   CommentLike[]
-  notifications        Notification[]
+  id            String         @id @default(uuid())
+  postId        String
+  authorId      String
+  text          String
+  likes         Int            @default(0)
+  createdAt     DateTime       @default(now())
+  parentId      String?
+  author        User           @relation("UserComments", fields: [authorId], references: [id])
+  post          Post           @relation("PostComments", fields: [postId], references: [id])
+  parent        Comment?       @relation("CommentReplies", fields: [parentId], references: [id])
+  replies       Comment[]      @relation("CommentReplies")
+  likedBy       CommentLike[]
+  notifications Notification[]
 }
 
 model CommentLike {
@@ -124,5 +126,5 @@ model Lounge {
   bannerUrl   String
   profileUrl  String
   posts       Post[]
-  followers   User[]  @relation("LoungeFollowers")
+  followers   User[] @relation("LoungeFollowers")
 }

--- a/backend/src/users/dto/user.dto.ts
+++ b/backend/src/users/dto/user.dto.ts
@@ -8,4 +8,6 @@ export interface UserDto {
   role: string;
   name?: string;
   followedLounges?: string[];
+  followers?: string[];
+  following?: string[];
 }

--- a/backend/src/users/users.controller.ts
+++ b/backend/src/users/users.controller.ts
@@ -6,6 +6,7 @@ import {
   UseGuards,
   Logger,
   Put,
+  Post,
   UseInterceptors,
   UploadedFile,
   InternalServerErrorException,
@@ -124,6 +125,40 @@ export class UsersController {
   @Get(':username/comments')
   getUserComments(@Param('username') username: string) {
     return this.usersService.getCommentsByUsername(username);
+  }
+
+  @UseGuards(JwtAuthGuard)
+  @Post(':username/follow')
+  async followUser(
+    @Param('username') username: string,
+    @Req() req: Request & { user: { sub: string } },
+  ) {
+    const user = await this.usersService.findByUsername(username);
+    await this.usersService.followUser(user.id, req.user.sub);
+    return { success: true };
+  }
+
+  @UseGuards(JwtAuthGuard)
+  @Delete(':username/follow')
+  async unfollowUser(
+    @Param('username') username: string,
+    @Req() req: Request & { user: { sub: string } },
+  ) {
+    const user = await this.usersService.findByUsername(username);
+    await this.usersService.unfollowUser(user.id, req.user.sub);
+    return { success: true };
+  }
+
+  @Get(':username/followers')
+  async getFollowers(@Param('username') username: string) {
+    const user = await this.usersService.findByUsername(username);
+    return this.usersService.getFollowers(user.id);
+  }
+
+  @Get(':username/following')
+  async getFollowing(@Param('username') username: string) {
+    const user = await this.usersService.findByUsername(username);
+    return this.usersService.getFollowing(user.id);
   }
 
   @Get(':username')


### PR DESCRIPTION
## Summary
- allow users to follow each other via self-relation fields
- expose follower and following IDs in user DTO
- add migration for user follow join table

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a60d6dda948327a4da04ba2c041aa5