### PR TITLE
feat: add search endpoint and page

### DIFF
--- a/astrogram/src/lib/api.tsx
+++ b/astrogram/src/lib/api.tsx
@@ -338,3 +338,41 @@ export async function deleteProfile() {
   const res = await apiFetch('/users/me', { method: 'DELETE' });
   return res.json();
 }
+
+// --------------------------------------------------
+// Search API helpers
+
+export interface SearchUser {
+  id: string;
+  username: string | null;
+  avatarUrl: string | null;
+}
+
+export interface SearchLounge {
+  id: string;
+  name: string;
+  bannerUrl: string;
+}
+
+export interface PaginatedResults<T> {
+  results: T[];
+  total: number;
+  page: number;
+  limit: number;
+}
+
+export interface SearchResponse {
+  users?: PaginatedResults<SearchUser>;
+  lounges?: PaginatedResults<SearchLounge>;
+}
+
+export async function search(
+  query: string,
+  page: number = 1,
+  limit: number = 20,
+): Promise<SearchResponse> {
+  const res = await apiFetch(
+    `/search?q=${encodeURIComponent(query)}&page=${page}&limit=${limit}`,
+  );
+  return res.json();
+}

--- a/astrogram/src/pages/SearchPage.tsx
+++ b/astrogram/src/pages/SearchPage.tsx
@@ -1,16 +1,139 @@
-import React from 'react';
+import React, { useState } from 'react';
+import { search, SearchResponse } from '../lib/api';
 
 const SearchPage: React.FC = () => {
+  const [query, setQuery] = useState('');
+  const [page, setPage] = useState(1);
+  const [results, setResults] = useState<SearchResponse | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function performSearch(newPage: number) {
+    if (!query.trim()) return;
+    setLoading(true);
+    setError(null);
+    try {
+      const data = await search(query, newPage);
+      setResults(data);
+      setPage(newPage);
+    } catch (err) {
+      setError((err as Error).message);
+      setResults(null);
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  const onSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    await performSearch(1);
+  };
+
+  const hasResults = Boolean(
+    results &&
+      ((results.users?.results.length ?? 0) > 0 ||
+        (results.lounges?.results.length ?? 0) > 0),
+  );
+
+  const hasPrev = page > 1;
+  const hasNext = Boolean(
+    results &&
+      ((results.users &&
+        results.users.total > results.users.page * results.users.limit) ||
+        (results.lounges &&
+          results.lounges.total >
+            results.lounges.page * results.lounges.limit)),
+  );
+
   return (
-    <div className="flex flex-col items-center justify-center h-full text-center">
-      <img
-        src="/under-construction.svg"
-        alt="Building under construction with cranes"
-        className="w-64 h-64 mb-4"
-      />
-      <h1 className="text-2xl font-semibold">Search is under construction</h1>
+    <div className="max-w-xl mx-auto">
+      <form onSubmit={onSubmit} className="mb-4 flex gap-2">
+        <input
+          type="text"
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          placeholder="Search..."
+          className="flex-grow p-2 rounded bg-gray-800 border border-gray-700"
+        />
+        <button
+          type="submit"
+          className="px-4 py-2 bg-blue-600 rounded disabled:opacity-50"
+          disabled={loading}
+        >
+          Search
+        </button>
+      </form>
+
+      {loading && <p>Loading...</p>}
+      {error && <p className="text-red-500">{error}</p>}
+
+      {hasResults && (
+        <div className="space-y-6">
+          {results?.users?.results.length ? (
+            <div>
+              <h2 className="text-xl font-semibold mb-2">Users</h2>
+              <ul className="space-y-2">
+                {results.users.results.map((u) => (
+                  <li key={u.id} className="flex items-center gap-2">
+                    {u.avatarUrl && (
+                      <img
+                        src={u.avatarUrl}
+                        alt={u.username ?? 'user'}
+                        className="w-8 h-8 rounded-full"
+                      />
+                    )}
+                    <span>{u.username}</span>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          ) : null}
+
+          {results?.lounges?.results.length ? (
+            <div>
+              <h2 className="text-xl font-semibold mb-2">Lounges</h2>
+              <ul className="space-y-2">
+                {results.lounges.results.map((l) => (
+                  <li key={l.id} className="flex items-center gap-2">
+                    {l.bannerUrl && (
+                      <img
+                        src={l.bannerUrl}
+                        alt={l.name}
+                        className="w-8 h-8 rounded"
+                      />
+                    )}
+                    <span>{l.name}</span>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          ) : null}
+        </div>
+      )}
+
+      {results && !hasResults && !loading && <p>No results found</p>}
+
+      {results && (hasPrev || hasNext) && (
+        <div className="flex justify-between mt-4">
+          <button
+            onClick={() => performSearch(page - 1)}
+            disabled={!hasPrev || loading}
+            className="px-3 py-1 bg-gray-700 rounded disabled:opacity-50"
+          >
+            Previous
+          </button>
+          <button
+            onClick={() => performSearch(page + 1)}
+            disabled={!hasNext || loading}
+            className="px-3 py-1 bg-gray-700 rounded disabled:opacity-50"
+          >
+            Next
+          </button>
+        </div>
+      )}
     </div>
   );
 };
 
 export default SearchPage;
+

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -12,6 +12,7 @@ import { PostsModule } from './posts/post.module';
 import { CommentsModule } from './comments/comments.module';
 import { NotificationsModule } from './notifications/notifications.module';
 import { LoungesModule } from './lounges/lounges.module';
+import { SearchModule } from './search/search.module';
 
 @Module({
   imports: [
@@ -25,6 +26,7 @@ import { LoungesModule } from './lounges/lounges.module';
     CommentsModule,
     NotificationsModule,
     LoungesModule,
+    SearchModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/backend/src/lounges/lounges.module.ts
+++ b/backend/src/lounges/lounges.module.ts
@@ -10,5 +10,6 @@ import { PostsModule } from '../posts/post.module';
   imports: [PrismaModule, SupabaseModule.forRoot(), PostsModule],
   providers: [LoungesService, StorageService],
   controllers: [LoungesController],
+  exports: [LoungesService],
 })
 export class LoungesModule {}

--- a/backend/src/lounges/lounges.service.ts
+++ b/backend/src/lounges/lounges.service.ts
@@ -147,6 +147,32 @@ export class LoungesService {
     });
   }
 
+  async searchLounges(
+    query: string,
+    page = 1,
+    limit = 20,
+  ): Promise<{
+    results: { id: string; name: string; bannerUrl: string }[];
+    total: number;
+    page: number;
+    limit: number;
+  }> {
+    const skip = (page - 1) * limit;
+    const [items, total] = await this.prisma.$transaction([
+      this.prisma.lounge.findMany({
+        where: { name: { contains: query, mode: 'insensitive' } },
+        select: { id: true, name: true, bannerUrl: true },
+        skip,
+        take: limit,
+      }),
+      this.prisma.lounge.count({
+        where: { name: { contains: query, mode: 'insensitive' } },
+      }),
+    ]);
+
+    return { results: items, total, page, limit };
+  }
+
   async update(
     id: string,
     dto: UpdateLoungeDto,

--- a/backend/src/search/search.controller.ts
+++ b/backend/src/search/search.controller.ts
@@ -1,0 +1,67 @@
+import {
+  Controller,
+  Get,
+  Query,
+  BadRequestException,
+  Req,
+  HttpException,
+  HttpStatus,
+} from '@nestjs/common';
+import { UsersService } from '../users/users.service';
+import { LoungesService } from '../lounges/lounges.service';
+import { Request } from 'express';
+
+const WINDOW_MS = 60_000; // 1 minute
+const MAX_REQUESTS = 30;
+const rateMap = new Map<string, { count: number; start: number }>();
+
+@Controller('api/search')
+export class SearchController {
+  constructor(
+    private readonly users: UsersService,
+    private readonly lounges: LoungesService,
+  ) {}
+
+  @Get()
+  async search(
+    @Req() req: Request,
+    @Query('type') type?: string,
+    @Query('q') q?: string,
+    @Query('page') page = '1',
+    @Query('limit') limit = '20',
+  ) {
+    const now = Date.now();
+    const ip = req.ip ?? 'unknown';
+    const record = rateMap.get(ip);
+    if (!record || now - record.start > WINDOW_MS) {
+      rateMap.set(ip, { count: 1, start: now });
+    } else {
+      if (record.count >= MAX_REQUESTS) {
+        throw new HttpException(
+          'Too many search requests',
+          HttpStatus.TOO_MANY_REQUESTS,
+        );
+      }
+      record.count++;
+    }
+
+    const query = q?.trim();
+    if (!query) {
+      throw new BadRequestException('Query parameter q is required');
+    }
+    const l = Math.min(parseInt(limit, 10) || 20, 50);
+    const p = parseInt(page, 10) || 1;
+
+    if (type === 'user' || type === 'users') {
+      return { users: await this.users.searchUsers(query, p, l) };
+    }
+    if (type === 'lounge' || type === 'lounges') {
+      return { lounges: await this.lounges.searchLounges(query, p, l) };
+    }
+    const [users, lounges] = await Promise.all([
+      this.users.searchUsers(query, p, l),
+      this.lounges.searchLounges(query, p, l),
+    ]);
+    return { users, lounges };
+  }
+}

--- a/backend/src/search/search.module.ts
+++ b/backend/src/search/search.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { SearchController } from './search.controller';
+import { UsersModule } from '../users/users.module';
+import { LoungesModule } from '../lounges/lounges.module';
+
+@Module({
+  imports: [UsersModule, LoungesModule],
+  controllers: [SearchController],
+})
+export class SearchModule {}

--- a/backend/test/search.e2e-spec.ts
+++ b/backend/test/search.e2e-spec.ts
@@ -1,0 +1,81 @@
+import { UsersService } from '../src/users/users.service';
+import { LoungesService } from '../src/lounges/lounges.service';
+import { SearchController } from '../src/search/search.controller';
+
+describe('Search services', () => {
+  it('searchUsers returns matching users', async () => {
+    const prisma: any = {
+      user: {
+        findMany: jest.fn().mockResolvedValue([
+          { id: '1', username: 'alice', avatarUrl: 'a.png' },
+        ]),
+        count: jest.fn().mockResolvedValue(1),
+      },
+      $transaction: (promises: any[]) => Promise.all(promises),
+    };
+    const service = new UsersService({} as any, {} as any, prisma);
+    const result = await service.searchUsers('ali', 1, 20);
+    expect(result).toEqual({
+      results: [{ id: '1', username: 'alice', avatarUrl: 'a.png' }],
+      total: 1,
+      page: 1,
+      limit: 20,
+    });
+  });
+
+  it('searchLounges returns matching lounges', async () => {
+    const prisma: any = {
+      lounge: {
+        findMany: jest.fn().mockResolvedValue([
+          { id: '1', name: 'space', bannerUrl: 'b.png' },
+        ]),
+        count: jest.fn().mockResolvedValue(1),
+      },
+      $transaction: (promises: any[]) => Promise.all(promises),
+    };
+    const service = new LoungesService(prisma, {} as any);
+    const result = await service.searchLounges('spa', 1, 20);
+    expect(result).toEqual({
+      results: [{ id: '1', name: 'space', bannerUrl: 'b.png' }],
+      total: 1,
+      page: 1,
+      limit: 20,
+    });
+  });
+
+  it('search controller returns users and lounges when type is missing', async () => {
+    const users: any = {
+      searchUsers: jest.fn().mockResolvedValue({
+        results: [{ id: '1', username: 'alice', avatarUrl: 'a.png' }],
+        total: 1,
+        page: 1,
+        limit: 20,
+      }),
+    };
+    const lounges: any = {
+      searchLounges: jest.fn().mockResolvedValue({
+        results: [{ id: '2', name: 'space', bannerUrl: 'b.png' }],
+        total: 1,
+        page: 1,
+        limit: 20,
+      }),
+    };
+    const controller = new SearchController(users, lounges);
+    const req: any = { ip: '127.0.0.1' };
+    const result = await controller.search(req, undefined, 'a');
+    expect(result).toEqual({
+      users: {
+        results: [{ id: '1', username: 'alice', avatarUrl: 'a.png' }],
+        total: 1,
+        page: 1,
+        limit: 20,
+      },
+      lounges: {
+        results: [{ id: '2', name: 'space', bannerUrl: 'b.png' }],
+        total: 1,
+        page: 1,
+        limit: 20,
+      },
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add unified `/api/search` endpoint for querying users or lounges with pagination, result caps and simple rate limiting
- implement typed search helper and Search page with query form, loading state and pagination

## Testing
- `npm test --prefix backend`


------
https://chatgpt.com/codex/tasks/task_e_68ae10ed03108327a148df358019f3dc