### PR TITLE
feat: reposition search bar on search page

### DIFF
--- a/astrogram/src/pages/SearchPage.tsx
+++ b/astrogram/src/pages/SearchPage.tsx
@@ -46,7 +46,8 @@ const SearchPage: React.FC = () => {
   );
 
   return (
-    <div className="max-w-xl mx-auto">
+    <div className="max-w-xl mx-auto mt-8">
+      <h1 className="text-2xl font-semibold mb-4">Search</h1>
       <form onSubmit={onSubmit} className="mb-4 flex gap-2">
         <input
           type="text"


### PR DESCRIPTION
## Summary
- place search input below a new "Search" heading for better layout

## Testing
- `npm test` (frontend) *(fails: Missing script: "test")*
- `npm test` (backend)


------
https://chatgpt.com/codex/tasks/task_e_68b8f5e6533c832784557ccf4f5fc02c