### PR TITLE
Add default Oakland location when location access is denied

### DIFF
--- a/astrogram/src/hooks/useWeatherService.ts
+++ b/astrogram/src/hooks/useWeatherService.ts
@@ -7,6 +7,11 @@ type Coordinates = {
   longitude: number;
 };
 
+const DEFAULT_LOCATION: Coordinates = {
+  latitude: 37.8044,
+  longitude: -122.2712,
+};
+
 export const useWeatherService = () => {
   const [location, setLocation] = useState<Coordinates | null>(null);
   const [weather, setWeather] = useState<WeatherData | null>(null);
@@ -31,6 +36,12 @@ export const useWeatherService = () => {
       },
       (err) => {
         console.error(err);
+
+        if (err.code === err.PERMISSION_DENIED) {
+          setLocation(DEFAULT_LOCATION);
+          return;
+        }
+
         setError('Failed to retrieve location.');
         setLoading(false);
       }


### PR DESCRIPTION
## Summary
- add an Oakland, CA coordinate fallback for the weather service when users deny geolocation access
- retain existing error handling for other geolocation failures so the UI still reports unexpected issues

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c83d2e27548327b1ddef0926df7dcc