### PR TITLE
Add responsive grid layout for App main content

### DIFF
--- a/astrogram/src/App.tsx
+++ b/astrogram/src/App.tsx
@@ -48,45 +48,53 @@ const App: React.FC = () => {
       <Navbar />
 
       {/* Main Content */}
-      <main className="flex-grow max-w-screen-lg w-full mx-auto px-4 sm:px-6 md:px-8 pt-6 pb-24">
-        <Routes>
-          <Route path="/signup" element={<SignupPage />} />
-          <Route path="/auth/success" element={<AuthSuccessPage />} />
-          <Route element={<RequireProfileCompletion />}>
-            <Route path="/" element={<Feed />} />
-            {/* single-post detail view */}
-            <Route path="/posts/:id" element={<PostPage />} />
-            <Route path="/notifications" element={<NotificationsPage />} />
-            <Route path="/users/:username" element={<UserPage />} />
-            <Route path="/users/:username/:tab" element={<UserPage />} />
-            <Route path="/lounge" element={<LoungesPage />} />
-            <Route path="/lounge/:loungeName" element={<LoungePage />} />
-            <Route path="/lounge/:loungeName/posts/:postId" element={<LoungePostDetailPage />} />
-            <Route path="/search" element={<SearchPage />} />
-            <Route path="/lounge/:loungeName/post" element={<LoungePostPage />} />
-            <Route path="/upload" element={<UploadForm />} />
-            <Route path="/completeProfile" element={<CompleteProfilePage />} />
-            <Route path="/profile" element={<Navigate to="/profile/posts" replace />} />
-            <Route path="/profile/:tab" element={<ProfilePage />} />
-            <Route element={<RequireAdmin />}>
-              <Route path="/admin" element={<Navigate to="/admin/lounge" replace />} />
-              <Route path="/admin/:tab" element={<AdminPage />} />
+      <main className="flex-grow w-full mx-auto max-w-screen-2xl px-4 sm:px-6 md:px-8 pt-6 pb-24 lg:grid lg:grid-cols-[auto,1fr,auto] lg:gap-8">
+        <aside className="hidden lg:block lg:w-64" aria-hidden="true">
+          {/* Left sidebar placeholder */}
+        </aside>
+        <section className="w-full">
+          <Routes>
+            <Route path="/signup" element={<SignupPage />} />
+            <Route path="/auth/success" element={<AuthSuccessPage />} />
+            <Route element={<RequireProfileCompletion />}>
+              <Route path="/" element={<Feed />} />
+              {/* single-post detail view */}
+              <Route path="/posts/:id" element={<PostPage />} />
+              <Route path="/notifications" element={<NotificationsPage />} />
+              <Route path="/users/:username" element={<UserPage />} />
+              <Route path="/users/:username/:tab" element={<UserPage />} />
+              <Route path="/lounge" element={<LoungesPage />} />
+              <Route path="/lounge/:loungeName" element={<LoungePage />} />
+              <Route path="/lounge/:loungeName/posts/:postId" element={<LoungePostDetailPage />} />
+              <Route path="/search" element={<SearchPage />} />
+              <Route path="/lounge/:loungeName/post" element={<LoungePostPage />} />
+              <Route path="/upload" element={<UploadForm />} />
+              <Route path="/completeProfile" element={<CompleteProfilePage />} />
+              <Route path="/profile" element={<Navigate to="/profile/posts" replace />} />
+              <Route path="/profile/:tab" element={<ProfilePage />} />
+              <Route element={<RequireAdmin />}>
+                <Route path="/admin" element={<Navigate to="/admin/lounge" replace />} />
+                <Route path="/admin/:tab" element={<AdminPage />} />
+              </Route>
+              <Route
+                path="/weather"
+                element={
+                  <WeatherPage
+                    weather={weather}
+                    loading={loading}
+                    error={error}
+                    unit={unit}
+                    setUnit={setUnit}
+                  />
+                }
+              />
+              <Route path="*" element={<NotFoundPage />} />
             </Route>
-            <Route
-              path="/weather"
-              element={
-                <WeatherPage
-                  weather={weather}
-                  loading={loading}
-                  error={error}
-                  unit={unit}
-                  setUnit={setUnit}
-                />
-              }
-            />
-            <Route path="*" element={<NotFoundPage />} />
-          </Route>
-        </Routes>
+          </Routes>
+        </section>
+        <aside className="hidden lg:block lg:w-64" aria-hidden="true">
+          {/* Right sidebar placeholder */}
+        </aside>
       </main>
 
       {/* Bottom Navbar */}

--- a/astrogram/src/App.tsx
+++ b/astrogram/src/App.tsx
@@ -3,6 +3,7 @@ import Feed from './pages/Feed';
 import UploadForm from './components/UploadForm/UploadForm';
 import Navbar from './components/Navbar/Navbar';
 import BottomNavbar from './components/BottomNavbar/BottomNavbar';
+import DesktopNav from './components/Sidebar/DesktopNav';
 import WeatherPage from './pages/WeatherPage';
 import { useWeatherService } from './hooks/useWeatherService';
 import { useEffect } from "react";
@@ -48,9 +49,9 @@ const App: React.FC = () => {
       <Navbar />
 
       {/* Main Content */}
-      <main className="flex-grow w-full mx-auto max-w-screen-2xl px-4 sm:px-6 md:px-8 pt-6 pb-24 lg:grid lg:grid-cols-[auto,1fr,auto] lg:gap-8">
-        <aside className="hidden lg:block lg:w-64" aria-hidden="true">
-          {/* Left sidebar placeholder */}
+      <main className="flex-grow w-full mx-auto max-w-screen-2xl px-4 sm:px-6 md:px-8 pt-6 pb-24 md:grid md:grid-cols-[auto,1fr,auto] md:gap-8">
+        <aside className="hidden md:flex md:w-64 md:flex-col" aria-label="Primary navigation">
+          <DesktopNav />
         </aside>
         <section className="w-full">
           <Routes>
@@ -98,7 +99,9 @@ const App: React.FC = () => {
       </main>
 
       {/* Bottom Navbar */}
-      <BottomNavbar />
+      <div className="md:hidden">
+        <BottomNavbar />
+      </div>
     </div>
   );
 };

--- a/astrogram/src/App.tsx
+++ b/astrogram/src/App.tsx
@@ -49,7 +49,7 @@ const App: React.FC = () => {
       <Navbar />
 
       {/* Main Content */}
-      <main className="flex-grow w-full mx-auto max-w-screen-2xl px-4 sm:px-6 md:px-8 pt-6 pb-24 md:grid md:grid-cols-[auto,1fr,auto] md:gap-8">
+      <main className="flex-grow w-full mx-auto max-w-screen-2xl px-4 sm:px-6 md:px-8 pt-6 pb-24 md:grid md:grid-cols-[16rem,1fr,auto] md:gap-8">
         <aside className="hidden md:flex md:w-64 md:flex-col" aria-label="Primary navigation">
           <DesktopNav />
         </aside>

--- a/astrogram/src/components/Sidebar/DesktopNav.tsx
+++ b/astrogram/src/components/Sidebar/DesktopNav.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { NavLink, useLocation } from "react-router-dom";
-import { CloudSun, Home, Search } from "lucide-react";
+import { CloudSun, Home, Search, PlusCircle } from "lucide-react";
 import LavaLampIcon from "../Icons/LavaLampIcons";
 
 type IconComponent = React.ComponentType<{ className?: string }>;
@@ -15,6 +15,7 @@ type NavItem = {
 const navItems: NavItem[] = [
   { label: "Home", to: "/", icon: Home },
   { label: "Weather", to: "/weather", icon: CloudSun },
+  { label: "Post", to: "/upload", icon: PlusCircle },
   { label: "Lounges", to: "/lounge", icon: LavaLampIcon, matchStartsWith: "/lounge" },
   { label: "Search", to: "/search", icon: Search },
 ];
@@ -23,7 +24,7 @@ const DesktopNav: React.FC = () => {
   const location = useLocation();
 
   return (
-    <nav className="flex flex-col gap-2">
+    <nav className="fixed top-16 left-4 md:left-8 2xl:left-[calc((100vw-1536px)/2+2rem)] w-64 flex flex-col gap-2 max-h-[calc(100vh-4rem)] overflow-auto pr-2">
       {navItems.map(({ label, to, icon: Icon, matchStartsWith }) => {
         const isActive = matchStartsWith
           ? location.pathname.startsWith(matchStartsWith)
@@ -36,7 +37,7 @@ const DesktopNav: React.FC = () => {
             className={({ isActive: navLinkActive }) => {
               const active = navLinkActive || isActive;
 
-              return `group flex items-center gap-3 rounded-2xl px-4 py-2 text-sm font-medium transition-colors duration-200 ${
+              return `group flex items-center gap-4 rounded-2xl px-5 py-3 text-lg font-medium transition-colors duration-200 ${
                 active
                   ? "bg-slate-800 text-white shadow-lg shadow-slate-900/40"
                   : "text-slate-300 hover:bg-slate-800/60 hover:text-white"
@@ -45,7 +46,7 @@ const DesktopNav: React.FC = () => {
             aria-label={label}
           >
             <Icon
-              className="h-5 w-5 text-sky-400 transition-transform duration-200 group-hover:scale-105"
+              className="h-7 w-7 text-sky-400 transition-transform duration-200 group-hover:scale-105"
             />
             <span>{label}</span>
           </NavLink>

--- a/astrogram/src/components/Sidebar/DesktopNav.tsx
+++ b/astrogram/src/components/Sidebar/DesktopNav.tsx
@@ -1,0 +1,58 @@
+import React from "react";
+import { NavLink, useLocation } from "react-router-dom";
+import { CloudSun, Home, Search } from "lucide-react";
+import LavaLampIcon from "../Icons/LavaLampIcons";
+
+type IconComponent = React.ComponentType<{ className?: string }>;
+
+type NavItem = {
+  label: string;
+  to: string;
+  icon: IconComponent;
+  matchStartsWith?: string;
+};
+
+const navItems: NavItem[] = [
+  { label: "Home", to: "/", icon: Home },
+  { label: "Weather", to: "/weather", icon: CloudSun },
+  { label: "Lounges", to: "/lounge", icon: LavaLampIcon, matchStartsWith: "/lounge" },
+  { label: "Search", to: "/search", icon: Search },
+];
+
+const DesktopNav: React.FC = () => {
+  const location = useLocation();
+
+  return (
+    <nav className="flex flex-col gap-2">
+      {navItems.map(({ label, to, icon: Icon, matchStartsWith }) => {
+        const isActive = matchStartsWith
+          ? location.pathname.startsWith(matchStartsWith)
+          : location.pathname === to;
+
+        return (
+          <NavLink
+            key={label}
+            to={to}
+            className={({ isActive: navLinkActive }) => {
+              const active = navLinkActive || isActive;
+
+              return `group flex items-center gap-3 rounded-2xl px-4 py-2 text-sm font-medium transition-colors duration-200 ${
+                active
+                  ? "bg-slate-800 text-white shadow-lg shadow-slate-900/40"
+                  : "text-slate-300 hover:bg-slate-800/60 hover:text-white"
+              }`;
+            }}
+            aria-label={label}
+          >
+            <Icon
+              className="h-5 w-5 text-sky-400 transition-transform duration-200 group-hover:scale-105"
+            />
+            <span>{label}</span>
+          </NavLink>
+        );
+      })}
+    </nav>
+  );
+};
+
+export default DesktopNav;

--- a/astrogram/src/pages/AdminPage.tsx
+++ b/astrogram/src/pages/AdminPage.tsx
@@ -70,7 +70,8 @@ const AdminPage: React.FC = () => {
   };
 
   return (
-    <div className="p-4 max-w-2xl mx-auto text-gray-200">
+    <div className="w-full py-8 lg:pl-64 flex justify-center">
+      <div className="w-full max-w-3xl px-0 sm:px-4 text-gray-200">
       <div className="border-b border-gray-700 mb-4 pt-4">
         <nav className="-mb-px flex justify-center space-x-8" aria-label="Admin tabs">
           <Link
@@ -157,6 +158,7 @@ const AdminPage: React.FC = () => {
 
       {active === 'users' && <div>User management coming soon.</div>}
       {active === 'posts' && <div>Post moderation coming soon.</div>}
+      </div>
     </div>
   );
 };

--- a/astrogram/src/pages/CompleteProfilePage.tsx
+++ b/astrogram/src/pages/CompleteProfilePage.tsx
@@ -67,10 +67,11 @@ const CompleteProfilePage: React.FC = () => {
   };
 
   return (
-    <form
-      onSubmit={handleSubmit}
-      className="max-w-md mx-auto bg-gray-800 p-6 rounded-xl space-y-6"
-    >
+    <div className="w-full py-8 lg:pl-64 flex justify-center">
+      <form
+        onSubmit={handleSubmit}
+        className="w-full max-w-md bg-gray-800 p-6 rounded-xl space-y-6"
+      >
       <h2 className="text-xl font-semibold text-center">Complete Your Profile</h2>
 
       {/* Username */}
@@ -152,7 +153,8 @@ const CompleteProfilePage: React.FC = () => {
           "Save Profile"
         )}
       </button>
-    </form>
+      </form>
+    </div>
   );
 };
 

--- a/astrogram/src/pages/LoungePage.tsx
+++ b/astrogram/src/pages/LoungePage.tsx
@@ -100,7 +100,8 @@ const LoungePage: React.FC = () => {
   }
 
   return (
-    <div className="py-6">
+    <div className="w-full py-8 lg:pl-64 flex justify-center">
+      <div className="w-full max-w-3xl px-0 sm:px-4">
       <div className="relative mb-12">
         <div className="w-full h-40 overflow-hidden">
           <img
@@ -161,7 +162,14 @@ const LoungePage: React.FC = () => {
           )}
         </div>
       </div>
-      <div className="w-full max-w-3xl mx-auto space-y-4">
+      {lounge.description && (
+        <div className="mb-6">
+          <p className="text-sm text-neutral-300 whitespace-pre-line">
+            {lounge.description}
+          </p>
+        </div>
+      )}
+      <div className="w-full space-y-4">
         {loadingPosts ? (
           <div>Loading posts...</div>
         ) : (
@@ -242,6 +250,7 @@ const LoungePage: React.FC = () => {
             );
           })
         )}
+      </div>
       </div>
     </div>
   );

--- a/astrogram/src/pages/LoungePostDetailPage.tsx
+++ b/astrogram/src/pages/LoungePostDetailPage.tsx
@@ -59,14 +59,30 @@ const LoungePostDetailPage: React.FC = () => {
     }
   };
 
-  if (loading) return <div className="py-6">Loading...</div>;
-  if (error) return <div className="py-6">{error}</div>;
-  if (!post) return <div className="py-6">Post not found.</div>;
+  if (loading)
+    return (
+      <div className="w-full py-8 lg:pl-64 flex justify-center">
+        <div className="w-full max-w-3xl px-0 sm:px-4">Loading...</div>
+      </div>
+    );
+  if (error)
+    return (
+      <div className="w-full py-8 lg:pl-64 flex justify-center">
+        <div className="w-full max-w-3xl px-0 sm:px-4">{error}</div>
+      </div>
+    );
+  if (!post)
+    return (
+      <div className="w-full py-8 lg:pl-64 flex justify-center">
+        <div className="w-full max-w-3xl px-0 sm:px-4">Post not found.</div>
+      </div>
+    );
 
   const isOwn = user?.username === post.username;
 
   return (
-    <div className="py-6">
+    <div className="w-full py-8 lg:pl-64 flex justify-center">
+      <div className="w-full max-w-3xl px-0 sm:px-4">
       <div className="flex items-center mb-4">
         <img
           src={post.avatarUrl}
@@ -110,6 +126,7 @@ const LoungePostDetailPage: React.FC = () => {
       <div dangerouslySetInnerHTML={{ __html: post.caption }} />
       <hr className="my-4 border-t border-white/20" />
       <Comments postId={post.id} />
+    </div>
     </div>
   );
 };

--- a/astrogram/src/pages/LoungePostPage.tsx
+++ b/astrogram/src/pages/LoungePostPage.tsx
@@ -139,7 +139,8 @@ const LoungePostPage: React.FC = () => {
   };
 
   return (
-    <div className="w-full max-w-2xl mx-auto py-6">
+    <div className="w-full py-8 lg:pl-64 flex justify-center">
+      <div className="w-full max-w-3xl px-0 sm:px-4">
       <h1 className="text-xl font-semibold mb-4">New Post</h1>
       <form onSubmit={handleSubmit} className="space-y-4">
         <div>
@@ -259,6 +260,7 @@ const LoungePostPage: React.FC = () => {
           {loading ? "Posting..." : "Post"}
         </button>
       </form>
+      </div>
     </div>
   );
 };

--- a/astrogram/src/pages/LoungesPage.tsx
+++ b/astrogram/src/pages/LoungesPage.tsx
@@ -35,8 +35,9 @@ const LoungesPage: React.FC = () => {
   const sortedLounges = [...lounges].sort(sortByLastPost);
 
   return (
-    <div className="mt-8">
-      <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+    <div className="w-full py-8 lg:pt-6 lg:pl-64 flex justify-center">
+      <div className="w-full max-w-3xl px-0 sm:px-4">
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
         {sortedLounges.map((lounge) => {
           const isFollowed = user?.followedLounges?.includes(lounge.id) ?? false;
           return (
@@ -86,6 +87,7 @@ const LoungesPage: React.FC = () => {
             </Link>
           );
         })}
+        </div>
       </div>
     </div>
   );

--- a/astrogram/src/pages/NotFoundPage.tsx
+++ b/astrogram/src/pages/NotFoundPage.tsx
@@ -3,6 +3,8 @@ import { Link } from 'react-router-dom';
 
 const NotFoundPage: React.FC = () => {
   return (
+    <div className="w-full py-8 lg:pl-64 flex justify-center">
+      <div className="w-full max-w-3xl px-0 sm:px-4">
     <div className="flex flex-col items-center justify-center py-20 text-center gap-4">
       <h1 className="text-4xl font-bold">404 - Page Not Found</h1>
       <p className="text-gray-400">The page you are looking for does not exist.</p>
@@ -12,6 +14,8 @@ const NotFoundPage: React.FC = () => {
       >
         Return Home
       </Link>
+    </div>
+      </div>
     </div>
   );
 };

--- a/astrogram/src/pages/NotificationsPage.tsx
+++ b/astrogram/src/pages/NotificationsPage.tsx
@@ -19,11 +19,12 @@ const NotificationsPage: React.FC = () => {
   }, [refresh]);
 
   return (
-    <div className="p-4 max-w-xl mx-auto text-gray-200">
+    <div className="w-full py-8 lg:pl-64 flex justify-center">
+      <div className="w-full max-w-3xl px-0 sm:px-4 text-gray-200">
       <h1 className="text-xl mb-4">Notifications</h1>
-      {loading ? (
-        <div>Loading…</div>
-      ) : (
+        {loading ? (
+          <div>Loading…</div>
+        ) : (
         <ul className="space-y-4">
           {items.map((n) => (
             <li key={n.id} className="flex gap-2 border-b border-white/20 pb-2">
@@ -55,6 +56,7 @@ const NotificationsPage: React.FC = () => {
           ))}
         </ul>
       )}
+      </div>
     </div>
   );
 };

--- a/astrogram/src/pages/PostPage.tsx
+++ b/astrogram/src/pages/PostPage.tsx
@@ -67,8 +67,8 @@ const PostPage: React.FC = () => {
 
   if (loading) {
     return (
-      <div className="w-full py-4 flex justify-center min-h-screen bg-gray-900 px-2">
-        <div className="w-full max-w-3xl px-0 sm:px-2 space-y-4">
+      <div className="w-full py-8 lg:pl-64 flex justify-center">
+        <div className="w-full max-w-3xl px-0 sm:px-4 space-y-4">
           <PostSkeleton />
           <CommentsSkeleton />
         </div>
@@ -76,15 +76,23 @@ const PostPage: React.FC = () => {
     )
   }
   if (error) {
-    return <div className="p-8 text-center text-red-500">{error}</div>
+    return (
+      <div className="w-full py-8 lg:pl-64 flex justify-center">
+        <div className="w-full max-w-3xl px-0 sm:px-4 text-red-500 text-center">{error}</div>
+      </div>
+    )
   }
   if (!post) {
-    return <div className="p-8 text-center">Post not found.</div>
+    return (
+      <div className="w-full py-8 lg:pl-64 flex justify-center">
+        <div className="w-full max-w-3xl px-0 sm:px-4 text-center">Post not found.</div>
+      </div>
+    )
   }
 
   return (
-    <div className="w-full py-4 flex justify-center min-h-screen bg-gray-900 px-2">
-      <div className="w-full max-w-3xl px-0 sm:px-2">
+    <div className="w-full py-8 lg:pl-64 flex justify-center">
+      <div className="w-full max-w-3xl px-0 sm:px-4">
         <PostCard {...post} />
         <Comments postId={post.id} />
       </div>

--- a/astrogram/src/pages/ProfilePage.tsx
+++ b/astrogram/src/pages/ProfilePage.tsx
@@ -69,7 +69,12 @@ export default function ProfilePage(): JSX.Element {
     };
   }, [previewUrl]);
 
-  if (!user) return <div className="p-4">Please sign in.</div>;
+  if (!user)
+    return (
+      <div className="w-full py-8 lg:pl-64 flex justify-center">
+        <div className="w-full max-w-3xl px-0 sm:px-4">Please sign in.</div>
+      </div>
+    );
 
   const handleAvatarChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
     const f = e.target.files?.[0];
@@ -137,7 +142,8 @@ export default function ProfilePage(): JSX.Element {
   const loungePosts = posts.filter((p) => p.loungeId);
 
   return (
-    <div className="p-4 max-w-2xl mx-auto text-gray-200">
+    <div className="w-full py-8 lg:pl-64 flex justify-center">
+      <div className="w-full max-w-3xl px-0 sm:px-4 text-gray-200">
       {/* Profile header */}
       <div className="flex items-center mb-4">
         {user.avatarUrl ? (
@@ -398,6 +404,7 @@ export default function ProfilePage(): JSX.Element {
           onConfirm={confirmDelete}
         />
       )}
+      </div>
     </div>
   );
 };

--- a/astrogram/src/pages/SearchPage.tsx
+++ b/astrogram/src/pages/SearchPage.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { search, SearchResponse } from '../lib/api';
+import { search, type SearchResponse } from '../lib/api';
 
 const SearchPage: React.FC = () => {
   const [query, setQuery] = useState('');
@@ -46,7 +46,9 @@ const SearchPage: React.FC = () => {
   );
 
   return (
-    <div className="max-w-xl mx-auto mt-8">
+    <div className="w-full py-8 lg:pl-64 flex justify-center">
+      <div className="w-full max-w-3xl px-0 sm:px-4">
+        <div className="max-w-xl mx-auto">
       <h1 className="text-2xl font-semibold mb-4">Search</h1>
       <form onSubmit={onSubmit} className="mb-4 flex gap-2">
         <input
@@ -132,6 +134,8 @@ const SearchPage: React.FC = () => {
           </button>
         </div>
       )}
+        </div>
+      </div>
     </div>
   );
 };

--- a/astrogram/src/pages/SignupPage.tsx
+++ b/astrogram/src/pages/SignupPage.tsx
@@ -16,7 +16,7 @@ const SignupPage: React.FC = () => {
   };
 
   return (
-    <div className="min-h-screen flex items-center justify-center bg-gray-50 dark:bg-gray-900">
+    <div className="min-h-screen flex items-center justify-center bg-gray-50 dark:bg-gray-900 lg:items-start lg:pt-16">
       <div className="max-w-sm w-full p-8 space-y-6 bg-white dark:bg-gray-800 rounded-xl shadow-md">
         <h1 className="text-2xl font-semibold text-center text-gray-800 dark:text-gray-100">
           Sign Up

--- a/astrogram/src/pages/UserPage.tsx
+++ b/astrogram/src/pages/UserPage.tsx
@@ -77,7 +77,8 @@ const UserPage: React.FC = () => {
   };
 
   return (
-    <div className="p-4 max-w-2xl mx-auto text-gray-200">
+    <div className="w-full py-8 lg:pl-64 flex justify-center">
+      <div className="w-full max-w-3xl px-0 sm:px-4 text-gray-200">
       {info && (
         <>
           <div className="flex items-center space-x-2 mb-2">
@@ -183,6 +184,7 @@ const UserPage: React.FC = () => {
           ))}
         </ul>
       )}
+    </div>
     </div>
   );
 };

--- a/astrogram/src/pages/WeatherPage.tsx
+++ b/astrogram/src/pages/WeatherPage.tsx
@@ -114,7 +114,8 @@ const WeatherPage: React.FC<WeatherPageProps> = ({ weather, loading, error, unit
   const icon = getWeatherIcon(currentCondition, isDaytime);
 
   return (
-    <div className="px-4 py-6 max-w-2xl mx-auto">
+    <div className="w-full py-8 lg:pl-64 flex justify-center">
+      <div className="w-full max-w-3xl px-0 sm:px-4">
       <WeatherHeader
         location={weather.coordinates}
         date={today.toLocaleDateString()}
@@ -164,6 +165,7 @@ const WeatherPage: React.FC<WeatherPageProps> = ({ weather, loading, error, unit
           </div>
         </div>
       )}
+      </div>
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- update the main layout container to use a responsive grid with support for future sidebars
- increase the available width on large screens and add placeholder aside elements for upcoming content areas

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68c85d07804c8327872e8da7b00d47dc