### PR TITLE
Add lounge back navigation control

### DIFF
--- a/astrogram/src/pages/LoungePostDetailPage.tsx
+++ b/astrogram/src/pages/LoungePostDetailPage.tsx
@@ -4,7 +4,7 @@ import { formatDistanceToNow } from "date-fns";
 import { apiFetch } from "../lib/api";
 import Comments, { type CommentsHandle } from "../components/Comments/Comments";
 import { useAuth } from "../hooks/useAuth";
-import { MoreVertical, Quote, Reply, Flag } from "lucide-react";
+import { MoreVertical, Quote, Reply, Flag, ArrowLeft } from "lucide-react";
 
 interface Post {
   id: string;
@@ -102,6 +102,17 @@ const LoungePostDetailPage: React.FC = () => {
   return (
     <div className="w-full py-8 flex justify-center">
       <div className="w-full max-w-3xl px-0 sm:px-4 space-y-8">
+        {loungeName && (
+          <div className="flex">
+            <Link
+              to={`/lounge/${encodeURIComponent(loungeName)}`}
+              className="inline-flex items-center gap-2 rounded-full border border-white/10 px-3 py-1.5 text-xs font-semibold text-gray-200 transition hover:bg-white/10"
+            >
+              <ArrowLeft className="h-4 w-4" />
+              Back to {loungeName}
+            </Link>
+          </div>
+        )}
         <article className="rounded-2xl border border-white/10 bg-gray-950/80 shadow-2xl backdrop-blur">
           <div className="flex flex-col md:flex-row">
             <aside className="md:w-60 border-b md:border-b-0 md:border-r border-white/10 bg-gray-950/60 p-5 text-center">


### PR DESCRIPTION
## Summary
- import the ArrowLeft icon for use on the lounge post detail page
- add a conditional back control linking to the parent lounge when a lounge name is provided
- match the control styling to existing rounded buttons for a consistent UI

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d35af85a8c8327adc6eeb0b291bcbd