### PR TITLE
Update lounge post button styling

### DIFF
--- a/astrogram/src/pages/LoungePage.tsx
+++ b/astrogram/src/pages/LoungePage.tsx
@@ -122,7 +122,7 @@ const LoungePage: React.FC = () => {
           {user && (
             <Link
               to={`/lounge/${encodeURIComponent(lounge.name)}/post`}
-              className="inline-flex items-center gap-2 text-white hover:text-gray-200 transition-colors no-underline"
+              className="inline-flex items-center gap-2 px-4 py-2 rounded bg-brand text-white hover:bg-brand-dark transition no-underline hover:no-underline focus:no-underline active:no-underline"
             >
               <PlusCircle className="w-4 h-4" />
               Post


### PR DESCRIPTION
## Summary
- import the PlusCircle icon for reuse alongside the existing lounge menu icon
- restyle the lounge post button with shared brand classes and include the icon before the label

## Testing
- No automated tests were run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d35d71f6b48327a33b4b65c147bb91