### PR TITLE
Publish Docker image metadata outputs for Fly deploy jobs

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -13,6 +13,9 @@ env:
 jobs:
   build:
     runs-on: ubuntu-latest
+    outputs:
+      image: ${{ steps.meta.outputs.image }}
+      digest: ${{ steps.meta.outputs.digest }}
     steps:
       - uses: actions/checkout@v4
 
@@ -32,4 +35,49 @@ jobs:
             .
 
       - name: Push image
+        if: github.event_name == 'push'
         run: docker push $FLY_REGISTRY:${{ github.sha }}
+
+      - name: Export image metadata
+        id: meta
+        env:
+          IMAGE: ${{ env.FLY_REGISTRY }}:${{ github.sha }}
+          GITHUB_EVENT_NAME: ${{ github.event_name }}
+        run: |
+          image="$IMAGE"
+          echo "image=$image" >> "$GITHUB_OUTPUT"
+
+          if [ "$GITHUB_EVENT_NAME" = "push" ]; then
+            digest="$(docker inspect --format='{{ index .RepoDigests 0 }}' "$image")"
+            echo "digest=$digest" >> "$GITHUB_OUTPUT"
+          fi
+
+  deploy-dev:
+    runs-on: ubuntu-latest
+    needs: build
+    if: github.event_name == 'push'
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: superfly/flyctl-actions/setup-flyctl@v1
+
+      - name: Deploy to development
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+        run: flyctl deploy --config fly.dev.toml --image ${{ coalesce(needs.build.outputs.digest, needs.build.outputs.image) }}
+
+  promote-production:
+    runs-on: ubuntu-latest
+    needs:
+      - build
+      - deploy-dev
+    if: github.event_name == 'push'
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: superfly/flyctl-actions/setup-flyctl@v1
+
+      - name: Deploy to production
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+        run: flyctl deploy --config fly.toml --image ${{ coalesce(needs.build.outputs.digest, needs.build.outputs.image) }}


### PR DESCRIPTION
## Summary
- publish the built Docker image tag and digest as outputs on the build job
- guard pushes to the Fly registry so only push events upload images
- wire development and production Fly deploy jobs to reuse the published image reference

## Testing
- not run (workflow-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d45065738c8327b36a8d5c5a748bfd