### PR TITLE
Ensure Fly deploy uses full image reference

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -16,6 +16,7 @@ jobs:
     outputs:
       image: ${{ steps.meta.outputs.image }}
       digest: ${{ steps.meta.outputs.digest }}
+      image_ref: ${{ steps.meta.outputs.image_ref }}
     steps:
       - uses: actions/checkout@v4
 
@@ -50,6 +51,7 @@ jobs:
         run: |
           echo "image=$IMAGE" >> "$GITHUB_OUTPUT"
           echo "digest=$DIGEST" >> "$GITHUB_OUTPUT"
+          echo "image_ref=$FLY_REGISTRY@${DIGEST}" >> "$GITHUB_OUTPUT"
 
 
   deploy-dev:
@@ -65,7 +67,7 @@ jobs:
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
 
-        run: flyctl deploy --config fly.dev.toml --image ${{ needs.build.outputs.digest }}
+        run: flyctl deploy --config fly.dev.toml --image ${{ needs.build.outputs.image_ref }}
 
 
   promote-production:
@@ -84,5 +86,5 @@ jobs:
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
 
-        run: flyctl deploy --config fly.toml --image ${{ needs.build.outputs.digest }}
+        run: flyctl deploy --config fly.toml --image ${{ needs.build.outputs.image_ref }}
 


### PR DESCRIPTION
## Summary
- capture a registry-qualified image reference with the build digest in the docker-image workflow
- deploy both environments using the fully qualified image reference so flyctl resolves the built image

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68d4b29308c08327a4b327dd66751350