### PR TITLE
Potential fix for code scanning alert no. 13: Missing rate limiting

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -45,7 +45,8 @@
     "passport-jwt": "^4.0.1",
     "path": "^0.12.7",
     "reflect-metadata": "^0.2.2",
-    "rxjs": "^7.8.1"
+    "rxjs": "^7.8.1",
+    "express-rate-limit": "^8.1.0"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3.2.0",


### PR DESCRIPTION
Potential fix for [https://github.com/cbejar93/astroSocial/security/code-scanning/13](https://github.com/cbejar93/astroSocial/security/code-scanning/13)

To fix the problem, a rate-limiting middleware should be added to the Express server. The best approach is to use the standard `express-rate-limit` package, which integrates easily and has no side effects on functionality. The rate limiter should be added before the catch-all route (`server.use((req, res, next) => {...})` on line 58), but after static files serving and logging middleware. The rate limiter can be configured for a sensible default, such as 100 requests per 15 minutes per IP. This protects the file system by throttling excessive requests. 

Changes required:
- Import `express-rate-limit` at the top.
- Create a rate limiter instance (e.g., 100 requests per 15 minutes).
- Apply rate limiter middleware to routes serving static files and the catch-all route. Since express middlewares are chained, using `server.use(limiter);` just before the catch-all middleware is clean and sufficient.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
