### PR TITLE
Fix profile completion redirect after avatar skip

### DIFF
--- a/astrogram/src/hooks/useAuth.ts
+++ b/astrogram/src/hooks/useAuth.ts
@@ -14,6 +14,9 @@ export function useAuth() {
       logout: () => {
         throw new Error('AuthProvider is missing');
       },
+      refreshUser: async () => {
+        throw new Error('AuthProvider is missing');
+      },
       updateFollowedLounge: async () => {
         throw new Error('AuthProvider is missing');
       },

--- a/astrogram/src/pages/CompleteProfilePage.tsx
+++ b/astrogram/src/pages/CompleteProfilePage.tsx
@@ -4,11 +4,13 @@ import type { FormEvent } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { UploadCloud }             from "lucide-react";
 import { apiFetch } from '../lib/api';
+import { useAuth } from '../hooks/useAuth';
 
 
 
 const CompleteProfilePage: React.FC = () => {
   const navigate        = useNavigate();
+  const { refreshUser } = useAuth();
 
   const [imageFile, setImageFile] = useState<File | null>(null);
   const [error, setError]         = useState<string | null>(null);
@@ -57,6 +59,7 @@ const CompleteProfilePage: React.FC = () => {
       });
 
       if (!res.ok) throw new Error('Failed to update profile');
+      await refreshUser();
       navigate('/', { replace: true });
     } catch (err: unknown) {
       const message = err instanceof Error ? err.message : 'Something went wrong';


### PR DESCRIPTION
## Summary
- expose a `refreshUser` helper from the auth context so the latest profile data can be pulled into state and localStorage
- update the complete profile page to call `refreshUser` after a successful save so navigation to the feed is not immediately reverted

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d5d812cb1c8327b3608a202b0085ef