### PR TITLE
Handle duplicate username errors in profile update

### DIFF
--- a/backend/src/users/users.service.spec.ts
+++ b/backend/src/users/users.service.spec.ts
@@ -154,5 +154,14 @@ describe('UsersService', () => {
       ).rejects.toBeInstanceOf(BadRequestException);
       expect(prisma.user.update).not.toHaveBeenCalled();
     });
+
+    it("throws a BadRequestException when the username isn't unique", async () => {
+      prisma.user.update.mockRejectedValue({ code: 'P2002' });
+
+      await expect(
+        service.updateProfile('user-123', 'duplicate'),
+      ).rejects.toThrow("username's must be unique");
+      expect(prisma.user.update).toHaveBeenCalled();
+    });
   });
 });


### PR DESCRIPTION
## Summary
- surface a clear validation error when Prisma raises a duplicate-username constraint
- add a helper to detect unique constraint violations in the users service
- extend the users service spec to cover the duplicate-username scenario

## Testing
- `npx jest src/users/users.service.spec.ts`


------
https://chatgpt.com/codex/tasks/task_e_68d6c8ca57888327bab1479fb3037891