### PR TITLE
Add saved posts feature

### DIFF
--- a/astrogram/src/App.tsx
+++ b/astrogram/src/App.tsx
@@ -21,6 +21,7 @@ import LoungesPage from './pages/LoungesPage'
 import LoungePostPage from './pages/LoungePostPage'
 import LoungePostDetailPage from './pages/LoungePostDetailPage'
 import AdminPage from './pages/AdminPage'
+import SavedPage from './pages/SavedPage'
 
 import NotFoundPage from './pages/NotFoundPage'
 import SearchPage from './pages/SearchPage'
@@ -64,6 +65,7 @@ const App: React.FC = () => {
                 {/* single-post detail view */}
                 <Route path="/posts/:id" element={<PostPage />} />
                 <Route path="/notifications" element={<NotificationsPage />} />
+                <Route path="/saved" element={<SavedPage />} />
                 <Route path="/users/:username" element={<UserPage />} />
                 <Route path="/users/:username/:tab" element={<UserPage />} />
                 <Route path="/lounge" element={<LoungesPage />} />

--- a/astrogram/src/lib/api.tsx
+++ b/astrogram/src/lib/api.tsx
@@ -215,9 +215,36 @@ export async function interactWithPost(
     return interactWithPost(postId, 'share');
   }
   
-  export function repostPost(postId: string) {
-    return interactWithPost(postId, 'repost');
+export function repostPost(postId: string) {
+  return interactWithPost(postId, 'repost');
+}
+
+export async function savePost(postId: string) {
+  const res = await apiFetch(`/posts/${postId}/save`, { method: 'POST' });
+  if (!res.ok) {
+    throw new Error(`Failed to save post (${res.status})`);
   }
+  return res.json();
+}
+
+export async function unsavePost(postId: string) {
+  const res = await apiFetch(`/posts/${postId}/save`, { method: 'DELETE' });
+  if (!res.ok) {
+    throw new Error(`Failed to unsave post (${res.status})`);
+  }
+  return res.json();
+}
+
+export async function fetchSavedPosts<Item = unknown>(
+  page: number = 1,
+  limit: number = 20,
+): Promise<FeedResponse<Item>> {
+  const res = await apiFetch(`/posts/saved?page=${page}&limit=${limit}`);
+  if (!res.ok) {
+    throw new Error(`Failed to fetch saved posts (${res.status})`);
+  }
+  return res.json();
+}
 
 // --------------------------------------------------
 // Comments API helpers

--- a/astrogram/src/pages/PostPage.tsx
+++ b/astrogram/src/pages/PostPage.tsx
@@ -52,6 +52,8 @@ const PostPage: React.FC = () => {
           shares:     data.shares,
           reposts:    data.reposts,
           likedByMe:  data.likedByMe,
+          savedByMe:  data.savedByMe,
+          saves:      data.saves,
           repostedByMe: data.repostedByMe,
           authorId:   data.authorId,
           ...(data.repostedBy ? { repostedBy: data.repostedBy } : {}),

--- a/astrogram/src/pages/SavedPage.tsx
+++ b/astrogram/src/pages/SavedPage.tsx
@@ -1,0 +1,117 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import PostCard, { type PostCardProps } from '../components/PostCard/PostCard';
+import PostSkeleton from '../components/PostCard/PostSkeleton';
+import { fetchSavedPosts } from '../lib/api';
+
+const PAGE_SIZE = 20;
+
+const SavedPage: React.FC = () => {
+  const [loading, setLoading] = useState(true);
+  const [posts, setPosts] = useState<PostCardProps[]>([]);
+  const [page, setPage] = useState(0);
+  const [hasMore, setHasMore] = useState(true);
+  const [isFetchingNext, setIsFetchingNext] = useState(false);
+  const sentinelRef = useRef<HTMLDivElement | null>(null);
+
+  const loadPage = useCallback(async (nextPage: number) => {
+    if (nextPage === 1) {
+      setLoading(true);
+    }
+
+    setIsFetchingNext(true);
+
+    try {
+      const response = await fetchSavedPosts<PostCardProps>(nextPage, PAGE_SIZE);
+
+      setPosts((prev) => {
+        if (nextPage === 1) {
+          return response.posts;
+        }
+
+        const existingIds = new Set(prev.map((post) => post.id));
+        const appendedPosts = response.posts.filter(
+          (post) => !existingIds.has(post.id),
+        );
+
+        return [...prev, ...appendedPosts];
+      });
+
+      setPage(nextPage);
+      setHasMore(
+        response.posts.length > 0 && nextPage * PAGE_SIZE < response.total,
+      );
+    } catch (error) {
+      console.error('Failed to load saved posts', error);
+    } finally {
+      if (nextPage === 1) {
+        setLoading(false);
+      }
+
+      setIsFetchingNext(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    loadPage(1);
+  }, [loadPage]);
+
+  useEffect(() => {
+    const sentinel = sentinelRef.current;
+
+    if (!sentinel) {
+      return () => {};
+    }
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        const [entry] = entries;
+        if (entry.isIntersecting && !isFetchingNext && hasMore) {
+          loadPage(page + 1);
+        }
+      },
+      { threshold: 0.1 },
+    );
+
+    observer.observe(sentinel);
+
+    return () => {
+      observer.disconnect();
+    };
+  }, [loadPage, hasMore, isFetchingNext, page]);
+
+  const handleDeleted = useCallback((id: string) => {
+    setPosts((prev) => prev.filter((post) => post.id !== id));
+  }, []);
+
+  return (
+    <div className="w-full py-8 lg:pl-64 flex justify-center">
+      <div className="w-full max-w-3xl px-0 sm:px-4 space-y-4">
+        <h1 className="text-2xl font-semibold text-white">Saved posts</h1>
+
+        {loading ? (
+          <div className="space-y-4">
+            <PostSkeleton />
+            <PostSkeleton />
+            <PostSkeleton />
+          </div>
+        ) : posts.length === 0 ? (
+          <div className="text-center text-neutral-400 py-12">
+            You haven't saved any posts yet.
+          </div>
+        ) : (
+          posts.map((post) => (
+            <PostCard key={post.id} {...post} onDeleted={handleDeleted} />
+          ))
+        )}
+
+        {!loading && posts.length > 0 && (
+          <div ref={sentinelRef} className="h-10" aria-hidden="true">
+            {isFetchingNext && <PostSkeleton />}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default SavedPage;

--- a/backend/prisma/migrations/20250715174437_add_saved_posts/migration.sql
+++ b/backend/prisma/migrations/20250715174437_add_saved_posts/migration.sql
@@ -1,0 +1,13 @@
+-- CreateTable
+CREATE TABLE "SavedPost" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "postId" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "SavedPost_pkey" PRIMARY KEY ("id"),
+    CONSTRAINT "SavedPost_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE,
+    CONSTRAINT "SavedPost_postId_fkey" FOREIGN KEY ("postId") REFERENCES "Post"("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "SavedPost_one_save_per_user_per_post_key" ON "SavedPost"("userId", "postId");

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -41,6 +41,7 @@ model User {
   followedLounges   Lounge[]          @relation("LoungeFollowers")
   followers         User[]            @relation("UserFollows")
   following         User[]            @relation("UserFollows")
+  savedPosts        SavedPost[]
 
   @@unique([provider, providerId], name: "provider_providerId")
 }
@@ -63,6 +64,7 @@ model Post {
   lounge           Lounge?           @relation(fields: [loungeId], references: [id])
   interactions     PostInteraction[]
   notifications    Notification[]
+  savedBy          SavedPost[]
 }
 
 model Comment {
@@ -102,6 +104,17 @@ model PostInteraction {
   createdAt DateTime        @default(now())
 
   @@unique([postId, userId, type], name: "one_interaction_per_user_per_post")
+}
+
+model SavedPost {
+  id        String   @id @default(uuid())
+  user      User     @relation(fields: [userId], references: [id])
+  userId    String
+  post      Post     @relation(fields: [postId], references: [id])
+  postId    String
+  createdAt DateTime @default(now())
+
+  @@unique([userId, postId], name: "one_save_per_user_per_post")
 }
 
 model Notification {

--- a/backend/src/posts/dto/feed.dto.ts
+++ b/backend/src/posts/dto/feed.dto.ts
@@ -10,6 +10,8 @@ export interface FeedPostDto {
   shares: number;
   reposts: number;
   likedByMe: boolean;
+  savedByMe: boolean;
+  saves: number;
   repostedByMe: boolean;
   repostedBy?: string;
   title?: string;

--- a/backend/src/posts/post.controller.ts
+++ b/backend/src/posts/post.controller.ts
@@ -154,6 +154,59 @@ export class PostsController {
         }
     }
 
+    @UseGuards(JwtAuthGuard)
+    @Post(':id/save')
+    async savePost(@Req() req: any, @Param('id') postId: string) {
+        const userId = req.user.sub as string;
+        this.logger.log(`User ${userId} → SAVE POST → ${postId}`);
+        try {
+            const result = await this.posts.savePost(userId, postId);
+            this.logger.log(`SAVE POST: saved=${result.saved}, total=${result.count}`);
+            return result;
+        } catch (err: any) {
+            this.logger.error(`SAVE POST failed for ${postId}: ${err.message}`, err.stack);
+            throw err;
+        }
+    }
+
+    @UseGuards(JwtAuthGuard)
+    @Delete(':id/save')
+    async unsavePost(@Req() req: any, @Param('id') postId: string) {
+        const userId = req.user.sub as string;
+        this.logger.log(`User ${userId} → UNSAVE POST → ${postId}`);
+        try {
+            const result = await this.posts.unsavePost(userId, postId);
+            this.logger.log(`UNSAVE POST: saved=${result.saved}, total=${result.count}`);
+            return result;
+        } catch (err: any) {
+            this.logger.error(`UNSAVE POST failed for ${postId}: ${err.message}`, err.stack);
+            throw err;
+        }
+    }
+
+    @UseGuards(JwtAuthGuard)
+    @Get('saved')
+    async getSavedPosts(
+        @Req() req: any,
+        @Query('page') page = '1',
+        @Query('limit') limit = '20',
+    ): Promise<FeedResponseDto> {
+        const userId = req.user.sub as string;
+        const p = parseInt(page, 10) || 1;
+        const l = parseInt(limit, 10) || 20;
+        this.logger.log(`User ${userId} → FETCH SAVED POSTS (page=${p}, limit=${l})`);
+
+        try {
+            return await this.posts.getSavedPosts(userId, p, l);
+        } catch (err: any) {
+            this.logger.error(
+                `FETCH SAVED POSTS failed for ${userId}: ${err.message}`,
+                err.stack,
+            );
+            throw err;
+        }
+    }
+
     @Get(':id')
     @UseGuards(OptionalAuthGuard)  // if you want only logged‑in users, otherwise drop this
     async getPost(


### PR DESCRIPTION
## Summary
- add a SavedPost join table and migration to persist bookmarks
- expose save/unsave endpoints plus saved feed responses that include saved counts
- surface saved state in the React client, including a saved posts page and bookmark toggle

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d6fe650e588327902a98ad5c90de0c