### PR TITLE
Include lounge details in notifications

### DIFF
--- a/astrogram/src/lib/api.tsx
+++ b/astrogram/src/lib/api.tsx
@@ -336,6 +336,7 @@ export interface NotificationItem {
   actor: { username: string; avatarUrl: string };
   postId?: string;
   commentId?: string;
+  loungeName?: string;
 }
 
 export async function fetchNotifications(): Promise<NotificationItem[]> {

--- a/astrogram/src/pages/NotificationsPage.tsx
+++ b/astrogram/src/pages/NotificationsPage.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from 'react';
+import { Link } from 'react-router-dom';
 
 import { fetchNotifications, type NotificationItem } from '../lib/api';
 
@@ -43,12 +44,16 @@ const NotificationsPage: React.FC = () => {
                 {n.postId && (
                   <>
                     {' '}
-                    <a
-                      href={`/posts/${n.postId}`}
+                    <Link
+                      to={
+                        n.loungeName
+                          ? `/lounge/${encodeURIComponent(n.loungeName)}/posts/${n.postId}`
+                          : `/posts/${n.postId}`
+                      }
                       className="underline text-teal-300 hover:text-teal-200"
                     >
                       View post
-                    </a>
+                    </Link>
                   </>
                 )}
               </div>

--- a/backend/src/notifications/notifications.service.ts
+++ b/backend/src/notifications/notifications.service.ts
@@ -26,6 +26,15 @@ export class NotificationsService {
       orderBy: { createdAt: 'desc' },
       include: {
         actor: { select: { username: true, avatarUrl: true } },
+        post: {
+          select: {
+            lounge: {
+              select: {
+                name: true,
+              },
+            },
+          },
+        },
       },
     });
     await this.prisma.notification.updateMany({
@@ -38,6 +47,7 @@ export class NotificationsService {
       timestamp: n.createdAt.toISOString(),
       postId: n.postId || undefined,
       commentId: n.commentId || undefined,
+      loungeName: n.post?.lounge?.name || undefined,
       actor: {
         username: n.actor.username!,
         avatarUrl: n.actor.avatarUrl || '/defaultPfp.png',


### PR DESCRIPTION
## Summary
- include each notification's post lounge when fetching from the backend
- surface optional lounge names through the front-end API typings
- update notification links to point to lounge-specific post routes when possible

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dc0b87aed08327be8a7ddbd928ff2f