### PR TITLE
Improve lounge quote readability

### DIFF
--- a/astrogram/src/index.css
+++ b/astrogram/src/index.css
@@ -35,6 +35,19 @@ main a:hover,
   text-decoration: underline;
 }
 
+.prose blockquote {
+  margin: 0.75rem 0;
+  padding: 0.75rem 1rem;
+  border-left: 0.25rem solid rgba(56, 189, 248, 0.8);
+  background-color: rgba(56, 189, 248, 0.12);
+  color: #bae6fd;
+  border-radius: 0.75rem;
+}
+
+.prose blockquote strong {
+  color: #e0f2fe;
+}
+
 @layer base {
   /* Reset margin and keep layout responsive */
   body {


### PR DESCRIPTION
## Summary
- give lounge comment blockquotes a distinct accent border, background, and text color to clearly differentiate quoted content

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dc48c1b9508327a743702326f7021a