### PR TITLE
Restrict saved access to authenticated users

### DIFF
--- a/astrogram/src/components/Navbar/Navbar.tsx
+++ b/astrogram/src/components/Navbar/Navbar.tsx
@@ -153,13 +153,15 @@ const Navbar = () => {
                 )}
               </ul>
             )}
-            <Link
-              to="/saved"
-              onClick={() => setSideMenuOpen(false)}
-              className="block mt-4 mb-1 text-lg font-semibold"
-            >
-              Saved
-            </Link>
+            {user && (
+              <Link
+                to="/saved"
+                onClick={() => setSideMenuOpen(false)}
+                className="block mt-4 mb-1 text-lg font-semibold"
+              >
+                Saved
+              </Link>
+            )}
             <Link
               to="/settings"
               onClick={() => setSideMenuOpen(false)}

--- a/astrogram/src/components/auth/RequireProfileCompletion.tsx
+++ b/astrogram/src/components/auth/RequireProfileCompletion.tsx
@@ -32,6 +32,10 @@ export const RequireProfileCompletion: React.FC = () => {
     return <Navigate to="/signup" replace />;
   }
 
+  if (pathname === "/saved" && !user) {
+    return <Navigate to="/signup" replace />;
+  }
+
   // redirect unauthenticated users away from lounge post creation
   if (/^\/lounge\/[^/]+\/post$/.test(pathname) && !user) {
     return <Navigate to="/signup" replace />;


### PR DESCRIPTION
## Summary
- hide the Saved link in the side menu for users who are not signed in
- gate the /saved route so unauthenticated visitors are redirected to signup

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68deb38bf0548327b91cc10d2f6bf0e8