### PR TITLE
Allow guest users to open post details from feed

### DIFF
--- a/astrogram/src/pages/PostPage.tsx
+++ b/astrogram/src/pages/PostPage.tsx
@@ -1,6 +1,5 @@
 import React, { useEffect, useState } from 'react'
 import { useParams, useNavigate } from 'react-router-dom'
-import { useAuth } from '../hooks/useAuth'
 
 import PostCard, { type PostCardProps } from '../components/PostCard/PostCard'
 import PostSkeleton                     from '../components/PostCard/PostSkeleton'
@@ -13,17 +12,9 @@ type FullPost = PostCardProps
 const PostPage: React.FC = () => {
   const { id }     = useParams<{ id: string }>()
   const nav        = useNavigate()
-  const { user, loading: authLoading } = useAuth()
   const [post, setPost]       = useState<FullPost | null>(null)
   const [loading, setLoading] = useState(true)
   const [error, setError]     = useState<string | null>(null)
-
-  // Redirect unauthenticated users to signup
-  useEffect(() => {
-    if (!authLoading && !user) {
-      nav('/signup', { replace: true })
-    }
-  }, [authLoading, user, nav])
 
   useEffect(() => {
     if (!id) {


### PR DESCRIPTION
## Summary
- remove the automatic signup redirect from the post detail page so signed-out visitors can view posts from the feed
- retain the existing post fetch logic to populate the PostCard and comments

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dec7b5cc688327a683957c9e87247c