### PR TITLE
Adjust weather times when Fahrenheit is selected

### DIFF
--- a/astrogram/src/components/Weather/CurrentWeatherCard.tsx
+++ b/astrogram/src/components/Weather/CurrentWeatherCard.tsx
@@ -1,4 +1,5 @@
 import { WiSunrise, WiSunset } from 'react-icons/wi';
+import { formatTimeForUnit } from '../../lib/time';
 
 
 type Props = {
@@ -13,7 +14,7 @@ type Props = {
 
 const CurrentWeatherCard: React.FC<Props> = ({ temperature, condition, icon, sunrise, sunset, unit, onToggle }) => {
 
-  const fmt = (t?: string) => t ? t.slice(0, 5) : '';
+  const fmt = (t?: string) => (t ? formatTimeForUnit(t, unit) : '');
 
 
   return (

--- a/astrogram/src/components/Weather/MoonPhaseCard.tsx
+++ b/astrogram/src/components/Weather/MoonPhaseCard.tsx
@@ -1,4 +1,5 @@
 import { WiMoonrise, WiMoonset } from 'react-icons/wi';
+import { formatTimeForUnit } from '../../lib/time';
 
 
 
@@ -8,6 +9,7 @@ interface MoonPhaseCardProps {
   moonrise?: string;         // "HH:MM:SS"
   moonset?: string;         // "HH:MM:SS"
   className: string;
+  unit: 'metric' | 'us';
 }
 
 const phaseIcons: Record<string, string> = {
@@ -21,10 +23,16 @@ const phaseIcons: Record<string, string> = {
   "Waning Crescent": "🌘",
 };
 
-const MoonPhaseCard: React.FC<MoonPhaseCardProps> = ({ phase, illumination, moonrise,
-  moonset, className }) => {
+const MoonPhaseCard: React.FC<MoonPhaseCardProps> = ({
+  phase,
+  illumination,
+  moonrise,
+  moonset,
+  className,
+  unit,
+}) => {
   const emoji = phaseIcons[phase] ?? "🌙";
-  const fmt = (t?: string) => (t ? t.slice(0, 5) : '--:--'); // drop seconds safely
+  const fmt = (t?: string) => (t ? formatTimeForUnit(t, unit) : '--:--');
   const illum =  phaseToIlluminationPercent(illumination);
 
   return (

--- a/astrogram/src/components/Weather/WeatherCard.tsx
+++ b/astrogram/src/components/Weather/WeatherCard.tsx
@@ -1,9 +1,11 @@
 import React from "react";
+import { formatHourLabel } from "../../lib/time";
 import type { WeatherDay, TimeBlock } from "../../types/weather";
 
 type WeatherCardProps = {
   day: WeatherDay;
   isToday?: boolean;
+  unit?: "metric" | "us";
 };
 
 const levelColors: Record<number, string> = {
@@ -45,7 +47,7 @@ function getClosestTimeBlock(): TimeBlock {
   return blocks[0].toString() as TimeBlock;
 }
 
-const WeatherCard: React.FC<WeatherCardProps> = ({ day, isToday = false }) => {
+const WeatherCard: React.FC<WeatherCardProps> = ({ day, isToday = false, unit = "metric" }) => {
   const activeTime = isToday ? getClosestTimeBlock() : null;
 
   return (
@@ -64,11 +66,18 @@ const WeatherCard: React.FC<WeatherCardProps> = ({ day, isToday = false }) => {
       <div className="grid grid-cols-[100px_repeat(6,1fr)] gap-x-1 gap-y-2 items-center px-4 pb-4">
         {/* Time headers */}
         <div></div>
-        {timeBlocks.map((time) => (
-          <div key={time} className={`text-sm text-center ${time === activeTime && isToday ? "text-cyan-400 font-semibold" : "text-gray-400"}`}>
-            {time}H
-          </div>
-        ))}
+        {timeBlocks.map((time) => {
+          const hour = Number.parseInt(time, 10);
+          const label = formatHourLabel(hour, unit);
+          return (
+            <div
+              key={time}
+              className={`text-sm text-center ${time === activeTime && isToday ? "text-cyan-400 font-semibold" : "text-gray-400"}`}
+            >
+              {label}
+            </div>
+          );
+        })}
 
         {/* Condition rows */}
 
@@ -83,12 +92,15 @@ const WeatherCard: React.FC<WeatherCardProps> = ({ day, isToday = false }) => {
               const colorClass = levelColors[level] ?? "bg-gray-700";
               const isActive = time === activeTime && isToday;
 
+              const hour = Number.parseInt(time, 10);
+              const label = formatHourLabel(hour, unit);
+
               return (
                 <div
                   key={`${String(condition)}-${time}`}
                   className={`w-6 h-6 mx-auto rounded ${colorClass} ${isActive ? "ring-2 ring-cyan-400" : ""
                     }`}
-                  title={`${String(condition)} at ${time}H = ${rawValue ?? "N/A"}`}
+                  title={`${String(condition)} at ${label} = ${rawValue ?? "N/A"}`}
                 />
               );
             })}

--- a/astrogram/src/components/Weather/__tests__/WeatherPage.timezone.test.ts
+++ b/astrogram/src/components/Weather/__tests__/WeatherPage.timezone.test.ts
@@ -5,6 +5,7 @@ import {
   isWithinDaylight,
   parseTimeParts,
 } from '../../../pages/WeatherPage';
+import { formatHourLabel, formatTimeForUnit } from '../../../lib/time';
 
 test('getZonedDateInfo resolves non-local timezone offsets', () => {
   const info = getZonedDateInfo('Pacific/Honolulu', new Date('2024-01-15T15:30:00Z'));
@@ -31,4 +32,18 @@ test('isWithinDaylight respects overnight sun events', () => {
   // Polar day scenario where sunset occurs after midnight local time
   assert.equal(isWithinDaylight('20:00:00', '02:00:00', 22, 0), true);
   assert.equal(isWithinDaylight('20:00:00', '02:00:00', 3, 0), false);
+});
+
+test('formatTimeForUnit toggles between 24h and 12h clocks', () => {
+  assert.equal(formatTimeForUnit('06:30:00', 'metric'), '06:30');
+  assert.equal(formatTimeForUnit('18:45:00', 'metric'), '18:45');
+  assert.equal(formatTimeForUnit('06:30:00', 'us'), '6:30 AM');
+  assert.equal(formatTimeForUnit('18:45:00', 'us'), '6:45 PM');
+});
+
+test('formatHourLabel respects selected unit', () => {
+  assert.equal(formatHourLabel(0, 'metric'), '0H');
+  assert.equal(formatHourLabel(15, 'metric'), '15H');
+  assert.equal(formatHourLabel(0, 'us'), '12 AM');
+  assert.equal(formatHourLabel(15, 'us'), '3 PM');
 });

--- a/astrogram/src/lib/time.ts
+++ b/astrogram/src/lib/time.ts
@@ -1,0 +1,72 @@
+export interface TimeParts {
+  hour: number;
+  minute: number;
+}
+
+export const parseTimeParts = (value?: string): TimeParts | null => {
+  if (!value) return null;
+  const [timeSection] = value.includes("T") ? value.split("T").slice(-1) : [value];
+  const [hour, minute] = timeSection.split(":");
+  const parsedHour = Number.parseInt(hour ?? "", 10);
+  const parsedMinute = Number.parseInt(minute ?? "", 10);
+  if (Number.isNaN(parsedHour) || Number.isNaN(parsedMinute)) return null;
+  return { hour: parsedHour, minute: parsedMinute };
+};
+
+export const isWithinDaylight = (
+  sunrise: string,
+  sunset: string,
+  currentHour: number,
+  currentMinute: number,
+): boolean => {
+  const sunriseParts = parseTimeParts(sunrise);
+  const sunsetParts = parseTimeParts(sunset);
+  if (!sunriseParts || !sunsetParts) return true;
+
+  const sunriseMinutes = sunriseParts.hour * 60 + sunriseParts.minute;
+  const sunsetMinutes = sunsetParts.hour * 60 + sunsetParts.minute;
+  const currentMinutes = currentHour * 60 + currentMinute;
+
+  if (sunsetMinutes === sunriseMinutes) {
+    return currentMinutes === sunriseMinutes;
+  }
+
+  if (sunsetMinutes < sunriseMinutes) {
+    return currentMinutes >= sunriseMinutes || currentMinutes < sunsetMinutes;
+  }
+
+  return currentMinutes >= sunriseMinutes && currentMinutes < sunsetMinutes;
+};
+
+const toTwoDigit = (value: number): string => value.toString().padStart(2, "0");
+
+export const formatTimeForUnit = (
+  value: string,
+  unit: "metric" | "us",
+): string => {
+  const parts = parseTimeParts(value);
+  if (!parts) return value;
+
+  const { hour, minute } = parts;
+
+  if (unit === "us") {
+    const normalizedHour = ((hour % 24) + 24) % 24;
+    const period = normalizedHour >= 12 ? "PM" : "AM";
+    const twelveHour = normalizedHour % 12 === 0 ? 12 : normalizedHour % 12;
+    return `${twelveHour}:${toTwoDigit(minute)} ${period}`;
+  }
+
+  return `${toTwoDigit(hour)}:${toTwoDigit(minute)}`;
+};
+
+export const formatHourLabel = (hour: number, unit: "metric" | "us"): string => {
+  const normalizedHour = ((hour % 24) + 24) % 24;
+
+  if (unit === "us") {
+    const period = normalizedHour >= 12 ? "PM" : "AM";
+    const twelveHour = normalizedHour % 12 === 0 ? 12 : normalizedHour % 12;
+    return `${twelveHour} ${period}`;
+  }
+
+  return `${normalizedHour}H`;
+};

--- a/astrogram/src/pages/WeatherPage.tsx
+++ b/astrogram/src/pages/WeatherPage.tsx
@@ -5,6 +5,7 @@ import WeatherCard from "../components/Weather/WeatherCard";
 import MoonPhaseCard from "../components/Weather/MoonPhaseCard";
 import WeatherSkeleton from "../components/Weather/WeatherSkeleton";
 import WindCard from "../components/Weather/WindCard";
+import { isWithinDaylight } from "../lib/time";
 import type { WeatherData } from "../types/weather";
 
 interface WeatherPageProps {
@@ -57,45 +58,7 @@ export const getZonedDateInfo = (
   return { isoDate, hour, minute, formattedDate };
 };
 
-export interface TimeParts {
-  hour: number;
-  minute: number;
-}
-
-export const parseTimeParts = (value?: string): TimeParts | null => {
-  if (!value) return null;
-  const [timeSection] = value.includes("T") ? value.split("T").slice(-1) : [value];
-  const [hour, minute] = timeSection.split(":");
-  const parsedHour = Number.parseInt(hour ?? "", 10);
-  const parsedMinute = Number.parseInt(minute ?? "", 10);
-  if (Number.isNaN(parsedHour) || Number.isNaN(parsedMinute)) return null;
-  return { hour: parsedHour, minute: parsedMinute };
-};
-
-export const isWithinDaylight = (
-  sunrise: string,
-  sunset: string,
-  currentHour: number,
-  currentMinute: number,
-): boolean => {
-  const sunriseParts = parseTimeParts(sunrise);
-  const sunsetParts = parseTimeParts(sunset);
-  if (!sunriseParts || !sunsetParts) return true;
-
-  const sunriseMinutes = sunriseParts.hour * 60 + sunriseParts.minute;
-  const sunsetMinutes = sunsetParts.hour * 60 + sunsetParts.minute;
-  const currentMinutes = currentHour * 60 + currentMinute;
-
-  if (sunsetMinutes === sunriseMinutes) {
-    return currentMinutes === sunriseMinutes;
-  }
-
-  if (sunsetMinutes < sunriseMinutes) {
-    return currentMinutes >= sunriseMinutes || currentMinutes < sunsetMinutes;
-  }
-
-  return currentMinutes >= sunriseMinutes && currentMinutes < sunsetMinutes;
-};
+export { isWithinDaylight, parseTimeParts } from "../lib/time";
 
 const WeatherPage: React.FC<WeatherPageProps> = ({ weather, loading, error, unit, setUnit }) => {
   const resolvedLocalZone =
@@ -176,7 +139,7 @@ const WeatherPage: React.FC<WeatherPageProps> = ({ weather, loading, error, unit
         <div className="overflow-x-auto px-0 sm:px-4 pb-4">
           <div className="flex gap-3 w-max">
             {futureWeatherData.map((day, index) => (
-              <WeatherCard key={day.date} day={day} isToday={index === 0} />
+              <WeatherCard key={day.date} day={day} isToday={index === 0} unit={unit} />
             ))}
           </div>
         </div>
@@ -190,6 +153,7 @@ const WeatherPage: React.FC<WeatherPageProps> = ({ weather, loading, error, unit
                 illumination={todayData.astro.moonPhase.illumination}
                 moonrise={todayData.astro.moonrise}
                 moonset={todayData.astro.moonset}
+                unit={unit}
               />
             </div>
 


### PR DESCRIPTION
## Summary
- add shared time utilities for parsing and formatting weather timestamps
- render sunrise, moonrise, and hourly forecast labels in 12-hour format when Fahrenheit is selected
- expand weather unit tests to cover the new time helpers

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dec6f3611c8327aa8c130416aa0db6