### PR TITLE
Add user temperature preference column and update endpoint

### DIFF
--- a/astrogram/src/contexts/AuthContext.tsx
+++ b/astrogram/src/contexts/AuthContext.tsx
@@ -8,7 +8,15 @@ import React, {
 
 } from "react";
 import type { ReactNode } from 'react';
-import { apiFetch, setAccessToken, followLounge, unfollowLounge, followUser, unfollowUser } from "../lib/api";
+import {
+  apiFetch,
+  setAccessToken,
+  followLounge,
+  unfollowLounge,
+  followUser,
+  unfollowUser,
+  updateTemperaturePreference as updateTemperaturePreferenceApi,
+} from "../lib/api";
 
 const API_BASE = import.meta.env.VITE_API_BASE_URL || "/api";
 
@@ -18,6 +26,7 @@ export interface User {
   avatarUrl?: string;
   profileComplete: boolean;
   role: string;
+  temperature: 'C' | 'F';
   followedLounges?: string[];
   followers?: string[];
   following?: string[];
@@ -39,6 +48,7 @@ export interface AuthContextType {
     username: string,
     follow: boolean,
   ) => Promise<void>;
+  updateTemperaturePreference: (temperature: 'C' | 'F') => Promise<User>;
 }
 
 export const AuthContext = createContext<AuthContextType | undefined>(undefined);
@@ -185,6 +195,16 @@ export const AuthProvider: React.FC<{ children: ReactNode }> = ({ children }) =>
     }
   };
 
+  const updateTemperaturePreference = useCallback(
+    async (temperature: 'C' | 'F'): Promise<User> => {
+      const updated = await updateTemperaturePreferenceApi(temperature);
+      setUser(updated);
+      localStorage.setItem('USER_SNAPSHOT', JSON.stringify(updated));
+      return updated;
+    },
+    [],
+  );
+
   return (
     <AuthContext.Provider
       value={{
@@ -195,6 +215,7 @@ export const AuthProvider: React.FC<{ children: ReactNode }> = ({ children }) =>
         refreshUser,
         updateFollowedLounge,
         updateFollowingUser,
+        updateTemperaturePreference,
       }}
     >
       {children}

--- a/astrogram/src/hooks/useAuth.ts
+++ b/astrogram/src/hooks/useAuth.ts
@@ -23,6 +23,9 @@ export function useAuth() {
       updateFollowingUser: async () => {
         throw new Error('AuthProvider is missing');
       },
+      updateTemperaturePreference: async () => {
+        throw new Error('AuthProvider is missing');
+      },
     };
   }
   return ctx;

--- a/astrogram/src/lib/api.tsx
+++ b/astrogram/src/lib/api.tsx
@@ -406,6 +406,15 @@ export async function deleteProfile() {
   return res.json();
 }
 
+export async function updateTemperaturePreference(temperature: 'C' | 'F') {
+  const res = await apiFetch('/users/me/temperature', {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ temperature }),
+  });
+  return res.json();
+}
+
 // --------------------------------------------------
 // Search API helpers
 

--- a/backend/prisma/migrations/20250715174438_add_user_temperature/migration.sql
+++ b/backend/prisma/migrations/20250715174438_add_user_temperature/migration.sql
@@ -1,0 +1,5 @@
+-- CreateEnum
+CREATE TYPE "TemperatureUnit" AS ENUM ('C', 'F');
+
+-- AlterTable
+ALTER TABLE "User" ADD COLUMN "temperature" "TemperatureUnit" NOT NULL DEFAULT 'F';

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -19,6 +19,11 @@ enum NotificationType {
   COMMENT_LIKE
 }
 
+enum TemperatureUnit {
+  C
+  F
+}
+
 model User {
   id                String            @id @default(uuid())
   emailEncrypted    String
@@ -31,6 +36,7 @@ model User {
   profileComplete   Boolean           @default(false)
   username          String?           @unique
   role              String            @default("USER")
+  temperature       TemperatureUnit   @default(F)
   comments          Comment[]         @relation("UserComments")
   posts             Post[]            @relation("UserPosts")
   originalPosts     Post[]            @relation("OriginalAuthor")

--- a/backend/src/users/dto/update-temperature.dto.ts
+++ b/backend/src/users/dto/update-temperature.dto.ts
@@ -1,0 +1,3 @@
+export interface UpdateTemperatureDto {
+  temperature: 'C' | 'F';
+}

--- a/backend/src/users/dto/user.dto.ts
+++ b/backend/src/users/dto/user.dto.ts
@@ -6,6 +6,7 @@ export interface UserDto {
   avatarUrl?: string;
   profileComplete: boolean;
   role: string;
+  temperature: 'C' | 'F';
   name?: string;
   followedLounges?: string[];
   followers?: string[];

--- a/backend/src/users/users.controller.ts
+++ b/backend/src/users/users.controller.ts
@@ -20,6 +20,7 @@ import { UsersService } from './users.service';
 import type { Request } from 'express';
 import { UserDto } from './dto/user.dto';
 import { FileInterceptor } from '@nestjs/platform-express';
+import { UpdateTemperatureDto } from './dto/update-temperature.dto';
 
 @Controller('api/users')
 export class UsersController {
@@ -102,6 +103,18 @@ export class UsersController {
 
       throw new InternalServerErrorException('Could not update profile');
     }
+  }
+
+  @Put('me/temperature')
+  @UseGuards(JwtAuthGuard)
+  async updateTemperature(
+    @Req() req: Request & { user: { sub: string } },
+    @Body() body: UpdateTemperatureDto,
+  ): Promise<UserDto> {
+    return this.usersService.updateTemperaturePreference(
+      req.user.sub,
+      body.temperature,
+    );
   }
 
   @Get('me/posts')

--- a/backend/src/users/users.service.spec.ts
+++ b/backend/src/users/users.service.spec.ts
@@ -3,6 +3,7 @@ import { SupabaseClient } from '@supabase/supabase-js';
 import { PrismaService } from '../prisma/prisma.service';
 import { StorageService } from '../storage/storage.service';
 import { UsersService } from './users.service';
+import { TemperatureUnit } from '@prisma/client';
 
 describe('UsersService', () => {
   let service: UsersService;
@@ -119,6 +120,7 @@ describe('UsersService', () => {
       avatarUrl: null,
       profileComplete: true,
       role: 'USER',
+      temperature: TemperatureUnit.F,
       followedLounges: [],
       followers: [],
       following: [],


### PR DESCRIPTION
## Summary
- add a temperature preference enum and column to the Prisma User model with a migration
- expose the temperature preference in user DTOs/services and add an authenticated endpoint to update it

## Testing
- npx jest users.service.spec.ts

------
https://chatgpt.com/codex/tasks/task_e_68deed360f148327a60117a259b0cfdf