### PR TITLE
Add locale-derived visit table to analytics dashboard

### DIFF
--- a/astrogram/src/lib/api.tsx
+++ b/astrogram/src/lib/api.tsx
@@ -277,6 +277,7 @@ export interface AnalyticsSummary {
     postInteractions: { type: string; count: number }[];
     commentLikes: number;
   };
+  visitsByLocation: { location: string; count: number }[];
 }
 
 export async function fetchAnalyticsSummary(


### PR DESCRIPTION
## Summary
- derive approximate visitor locales from session user agents in the analytics summary
- expose locale visit aggregates to the frontend analytics API contract
- render a privacy-preserving unique visits table with locale share details in the admin dashboard

## Testing
- npm run --prefix astrogram build
- npm run --prefix backend build *(fails: missing @nestjs/schedule package in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e0129b58fc83278dfcfabaab8b30fa