### PR TITLE
Close side menu when navigating to privacy policy

### DIFF
--- a/astrogram/src/components/Navbar/Navbar.tsx
+++ b/astrogram/src/components/Navbar/Navbar.tsx
@@ -181,7 +181,13 @@ const Navbar = () => {
           </div>
           <div className="absolute bottom-0 left-0 w-full p-4 text-sm space-y-1">
             <Link to="/terms" className="block">Terms and Conditions</Link>
-            <Link to="/privacy" className="block">Privacy Policy</Link>
+            <Link
+              to="/privacy"
+              className="block"
+              onClick={() => setSideMenuOpen(false)}
+            >
+              Privacy Policy
+            </Link>
             <a href="#" className="block">Community Notes</a>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- close the mobile side menu when the privacy policy link is selected so navigation proceeds cleanly

## Testing
- npm test *(fails: src/lib/analytics.ts expects VITE_API_BASE_URL to be defined during tests)*

------
https://chatgpt.com/codex/tasks/task_e_68e017ae66c0832780060f22251fdc42