### PR TITLE
feat: add content moderation endpoint

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -15,6 +15,7 @@ import { NotificationsModule } from './notifications/notifications.module';
 import { LoungesModule } from './lounges/lounges.module';
 import { SearchModule } from './search/search.module';
 import { AnalyticsModule } from './analytics/analytics.module';
+import { ModerationModule } from './moderation/moderation.module';
 
 @Module({
   imports: [
@@ -31,6 +32,7 @@ import { AnalyticsModule } from './analytics/analytics.module';
     LoungesModule,
     SearchModule,
     AnalyticsModule,
+    ModerationModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/backend/src/moderation/dto/check-moderation.dto.ts
+++ b/backend/src/moderation/dto/check-moderation.dto.ts
@@ -1,0 +1,18 @@
+import { IsArray, IsOptional, IsString } from 'class-validator';
+
+export class CheckModerationDto {
+  @IsOptional()
+  @IsArray()
+  @IsString({ each: true })
+  texts?: string[];
+
+  @IsOptional()
+  @IsArray()
+  @IsString({ each: true })
+  imageUrls?: string[];
+
+  @IsOptional()
+  @IsArray()
+  @IsString({ each: true })
+  imageBase64?: string[];
+}

--- a/backend/src/moderation/moderation.controller.ts
+++ b/backend/src/moderation/moderation.controller.ts
@@ -1,0 +1,13 @@
+import { Body, Controller, Post } from '@nestjs/common';
+import { ModerationService } from './moderation.service';
+import { CheckModerationDto } from './dto/check-moderation.dto';
+
+@Controller('api/moderation')
+export class ModerationController {
+  constructor(private readonly moderation: ModerationService) {}
+
+  @Post('check')
+  checkContent(@Body() payload: CheckModerationDto) {
+    return this.moderation.checkContent(payload);
+  }
+}

--- a/backend/src/moderation/moderation.module.ts
+++ b/backend/src/moderation/moderation.module.ts
@@ -1,18 +1,10 @@
-import { Module }         from '@nestjs/common'
-import { AnalyticsModule } from "src/analytics/analytics.module";
-
-
-
-
+import { Module } from '@nestjs/common';
+import { ModerationService } from './moderation.service';
+import { ModerationController } from './moderation.controller';
 
 @Module({
-  imports: [
-
-    AnalyticsModule,
-
-  ],
-  providers: [],
-  controllers: [],
-  exports: [],
+  providers: [ModerationService],
+  controllers: [ModerationController],
+  exports: [ModerationService],
 })
-export class PostsModule {}
+export class ModerationModule {}

--- a/backend/src/moderation/moderation.service.ts
+++ b/backend/src/moderation/moderation.service.ts
@@ -1,28 +1,53 @@
-import { Injectable } from "@nestjs/common";
-import OpenAI from "openai";
-const openai = new OpenAI();
+import { BadRequestException, Injectable } from '@nestjs/common';
+import OpenAI from 'openai';
+import { CheckModerationDto } from './dto/check-moderation.dto';
 
+type ModerationContentItem =
+  | { type: 'input_text'; text: string }
+  | { type: 'input_image'; image_url: { url: string } }
+  | { type: 'input_image'; image_base64: string };
 
 @Injectable()
 export class ModerationService {
+  private readonly client: OpenAI;
 
-    async checkContent() {
+  constructor() {
+    this.client = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
+  }
 
-        const moderation = await openai.moderations.create({
-            model: "omni-moderation-latest",
-            input: [
-                { type: "text", text: "...text to classify goes here..." },
-                {
-                    type: "image_url",
-                    image_url: {
-                        url: 'dsd'
-                    }
-                }
-            ],
-        });
+  async checkContent({ texts = [], imageUrls = [], imageBase64 = [] }: CheckModerationDto) {
+    const normalizedTexts = texts.filter((text) => text?.trim().length);
+    const normalizedUrls = imageUrls.filter((url) => url?.trim().length);
+    const normalizedBase64 = imageBase64.filter((value) => value?.trim().length);
 
+    if (!normalizedTexts.length && !normalizedUrls.length && !normalizedBase64.length) {
+      throw new BadRequestException('At least one text or image must be provided for moderation.');
     }
 
+    const content: ModerationContentItem[] = [
+      ...normalizedTexts.map<ModerationContentItem>((text) => ({ type: 'input_text', text })),
+      ...normalizedUrls.map<ModerationContentItem>((url) => ({ type: 'input_image', image_url: { url } })),
+      ...normalizedBase64.map<ModerationContentItem>((value) => ({ type: 'input_image', image_base64: value })),
+    ];
+
+    const response = await this.client.responses.create({
+      model: 'omni-moderation-latest',
+      input: [
+        {
+          role: 'user',
+          content,
+        },
+      ],
+    });
+
+    return {
+      id: response.id,
+      created: response.created,
+      model: response.model,
+      output: response.output,
+      usage: response.usage,
+    };
+  }
 }
 
 


### PR DESCRIPTION
## Summary
- add a moderation controller, service, and DTO to accept text or images for review
- wire the moderation module into the application and expose a POST endpoint
- implement OpenAI omni moderation requests that consolidate text and image inputs

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e402e21c9c8327adc26794b715829c