### PR TITLE
Enable Gamepad2 icon import in navigation components

### DIFF
--- a/astrogram/src/components/BottomNavbar/BottomNavbar.tsx
+++ b/astrogram/src/components/BottomNavbar/BottomNavbar.tsx
@@ -1,7 +1,7 @@
 // src/components/BottomNavbar.tsx
 import React from "react";
 import { NavLink, useLocation } from "react-router-dom";
-import { Home, CloudSun, User, Settings, ChartArea, Newspaper/*, Gamepad2*/ } from "lucide-react";
+import { Home, CloudSun, User, Settings, ChartArea, Newspaper, Gamepad2 } from "lucide-react";
 import LavaLampIcon from "../Icons/LavaLampIcons";
 import { useAuth } from "../../hooks/useAuth";
 

--- a/astrogram/src/components/Sidebar/DesktopNav.tsx
+++ b/astrogram/src/components/Sidebar/DesktopNav.tsx
@@ -12,7 +12,7 @@ import {
   ChevronUp,
   ChartArea,
   Newspaper,
-  // Gamepad2,
+  Gamepad2,
 } from "lucide-react";
 import LavaLampIcon from "../Icons/LavaLampIcons";
 import { fetchLounges } from "../../lib/api";


### PR DESCRIPTION
## Summary
This PR uncomments the `Gamepad2` icon import in the navigation components, making it available for use in the BottomNavbar and DesktopNav components.

## Key Changes
- Uncommented `Gamepad2` import in `BottomNavbar.tsx` (moved from commented to active import)
- Uncommented `Gamepad2` import in `DesktopNav.tsx` (changed from commented to active import)

## Details
The `Gamepad2` icon from the lucide-react library is now properly imported and available for use in both the bottom navigation bar and desktop navigation components. This suggests the icon is ready to be integrated into the UI, likely for a games or entertainment-related feature.

https://claude.ai/code/session_01WmkXu79Ahd1QopVAiCmPmK